### PR TITLE
Release v0.1.7: bounded per-level recursion budget (R-32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.1.7] - 2026-07-06
+
+### Fixed
+
+- **Recursion safety (no behavior change to existing templates).** Collapsed the
+  `walk`/`_walk` pair in the template walker into a single core recursion frame per
+  node (the template-path `ContextVar` is now set inline via `try/finally` instead of a
+  `@contextmanager`). Every existing template produces the same output and the same
+  errors; this only *raises the nesting depth at which the engine runs out of host call
+  stack*. Because the generated `transon-blockly` editor codec self-`include`s once per
+  document node (AD-030), its reachable depth was governed by this per-level frame cost,
+  not by `max_include_depth` — so deep self-`include`ing templates overflowed CPython's
+  default 1000-frame stack with a raw `RecursionError` before the documented `include`
+  depth limit was ever reached. Removing the redundant per-node frame lifts the reachable
+  self-`include` depth **57 → 75** at the default recursion limit, so the editor's deepest
+  generator (`G_encode`, nesting depth 41) now loads and round-trips with margin.
+  `SPECIFICATION.md` §4.6 gains a normative **Recursion budget** invariant (over-depth
+  MUST surface as the `include` depth-limit `TransformationError`, never a raw
+  `RecursionError`), and `tests/test_recursion_depth.py` locks the reachable depth and the
+  absence of the `walk`/`_walk` doubling. `walk()`'s signature and public API are
+  unchanged. (Roadmap R-32)
+
 ## [0.1.6] - 2026-07-02
 
 ### Changed

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -60,6 +60,7 @@
 | [R-29](#r-29-export-example-tags--curated-example-tiers-in-the-editor-metadata) | Export example tags + curated example tiers in the editor metadata | medium | done |
 | [R-30](#r-30-grow-the-curated-example-corpus-recipes--worked-examples) | Grow the curated example corpus (recipes + worked examples) | low | done |
 | [R-31](#r-31-normalize-exports-to-one-flat-example-corpus-name-references) | Normalize exports to one flat example corpus (name references) | medium | done |
+| [R-32](#r-32-bounded-per-level-recursion-budget-for-self-include-walks) | Bounded per-level recursion budget for self-`include` walks | medium | done |
 
 ---
 
@@ -936,6 +937,55 @@ emit the flat corpus + name references; orphans tagged `attr:names`; `METADATA_V
 `3.0`. Corpus invariants tested in `tests/test_docs.py` / `tests/test_metadata.py`: unique names,
 every reference resolves, every case reachable, curated cases tier-tag-only, reference examples
 never tier-tagged. `SPECIFICATION.md` §5/§5.1/§6.1 rewritten to the new shapes.
+
+---
+
+### R-32. Bounded per-level recursion budget for self-include walks
+
+**Status**: done · **Severity**: medium ·
+**Source**: [`proposals/transformer-recursion-depth-budget.md`](proposals/transformer-recursion-depth-budget.md)
+
+`walk()` does no work of its own — it opens the template-path context and delegates to `_walk()`,
+so **every** descent through a template node costs a `walk` **and** a `_walk` frame. Profiling the
+`transon-blockly` editor codec (which self-`include`s once per document node, AD-030) shows the
+redundant `_walk` layer is ~23 % of the live stack. The effect: a self-`include`ing template
+overflows CPython's call stack (default limit 1000) with a raw `RecursionError` **before**
+`max_include_depth` (50) is reached — so that logical limit is unreachable for recursive codecs, and
+the editor's own deepest generator (`G_encode`, nesting depth 41) cannot be loaded at all.
+
+**Impact if not fixed**: `max_include_depth` stays fictional for self-referential templates; deep
+inputs fail with an uncatalogued raw `RecursionError` instead of the documented `include` depth-limit
+`TransformationError`; `transon-blockly` cannot self-host its deepest projection (SPEC §6.5, FR-121).
+
+**Options**:
+
+1. **Collapse `walk` into `_walk`** — one core recursion frame per node, path `ContextVar` set inline
+   (`try/finally`, no `@contextmanager` generator). Behavior-identical; removes ~23 % of per-walk
+   stack cost. Measured: editor codec reach 37 → 49, `G_encode` (41) encodes; self-`include` walk
+   57 → 75. **(Recommended)**
+2. Also fold `walk_rule`'s own `_walk_with_path` (further headroom, not needed now) — deferred.
+3. `sys.setrecursionlimit(…)` — moves the guard, not the cost; risks a hard C-stack segfault on
+   constrained hosts (Pyodide/WASM). **Rejected.**
+
+**Decision (2026-07-05)**: option 1. Behavior-preserving recursion-safety fix.
+
+**Requirements**: fold `_walk`'s body into `walk` (`transformers.py`), keeping `walk()`'s signature
+and all `t.walk(…)` call sites unchanged; add a **Recursion budget** invariant to `SPECIFICATION.md`
+(one core frame per nesting level; self-`include`ing templates reach well past `G_encode`'s depth 41
+within the default recursion limit; over-depth raises the `include` depth-limit `TransformationError`,
+never `RecursionError`); add `tests/test_recursion_depth.py` guarding the reachable depth **and** the
+absence of the `walk`/`_walk` doubling (both red today, green after the fix — land in the same commit);
+changelog entry (recursion-safety, no behavior change to existing templates); minor version bump.
+`transon-blockly` then raises `CODEC_MAX_INCLUDE_DEPTH` 25 → ~40 as a separate, engine-gated change.
+
+**Shipped**: `walk`/`_walk` collapsed into a single frame in `transformers.py` (path `ContextVar`
+set inline via `try/finally`; `walk()`'s signature and every `t.walk(…)` call site unchanged;
+`_walk_with_path` retained for `walk_rule`/`validate`). Measured self-`include` reach lifts **57 →
+75** at CPython's default recursion limit, clearing `G_encode` (41) with margin; all 304 existing
+tests unchanged. `SPECIFICATION.md` §4.6 gains the normative **Recursion budget** invariant (also
+listed in §10). `tests/test_recursion_depth.py` guards the reachable depth, the clean over-depth
+`TransformationError`, and the absence of the `walk`/`_walk` doubling. The `transon-blockly`
+`CODEC_MAX_INCLUDE_DEPTH` raise remains a separate, engine-gated follow-up.
 
 ---
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -391,6 +391,15 @@ Other lookup failures (e.g. `TypeError` indexing a string with a string) →
 | `file` | `name`, `content` (both required, dynamic) | Calls the configured `file_writer(name, content)`. Skipped if either is `NO_CONTENT`. Always returns `NO_CONTENT` (so `map` over `file` yields `[]`). |
 | `include` | `name` (required, dynamic), `default` (optional, dynamic) | Loads a sub-`Transformer` via the configured `template_loader` and runs it against `context.this`. Variables/context do **not** cross the boundary — only the value. The `template_loader` is always called as `loader(name, context=...)` and handed an `IncludeContext` (parent loader, marker, depth guard, include-stack); it **constructs** the sub-`Transformer` itself (e.g. via `context.transformer(template)`). The sub-`Transformer` therefore inherits the parent transformer's marker by default (so a sub-template using the default marker stays consistent across the boundary; pass an explicit `marker` to `context.transformer` to pin a different one), the parent's `template_loader` propagates so recursive/self-`include`ing templates re-resolve without per-host patching, and the loaded instance is never mutated. Sub-result `NO_CONTENT` is propagated as this transformer's `NO_CONTENT` (or `default` when provided). Nested includes are tracked by name; exceeding `max_include_depth` (constructor parameter, default 50) raises `TransformationError` with the include chain in the message. |
 
+> **Recursion budget.** Walking one level of template nesting consumes a bounded, small number of
+> Python call-stack frames — one core recursion frame per node (no `walk`/`_walk`-style doubling).
+> Because the generated `transon-blockly` editor codec self-`include`s once per document node
+> (AD-030), its reachable nesting depth is governed by this budget, not by `max_include_depth`. The
+> engine therefore transforms self-`include`ing templates at nesting depths well past the editor's
+> deepest generator (`G_encode`, depth 41) within CPython's default recursion limit (1000).
+> Exceeding `max_include_depth` MUST surface as the `include` depth-limit `TransformationError`,
+> never a raw `RecursionError`. (Roadmap R-32.)
+
 ### 4.7 Built-in operators (`expr`)
 
 Each operator has a mnemonic and a code-style alias mapping to the same Python
@@ -652,6 +661,11 @@ tagged example cases.
 - `NO_CONTENT` skipping semantics in `map`/`object`/`file`/`filter` are part of the
   public contract (relied on by the corpus, e.g. `test_no_content.py`).
 - Iteration order: dict iteration follows insertion order (Python 3.7+ guarantee).
+- Recursion budget: walking one template-nesting level costs one core call-stack frame
+  (no `walk`/`_walk`-style per-node doubling), so self-`include`ing templates reach
+  depths well past `G_encode` (41) before the host stack overflows; over-depth surfaces
+  as the `include` depth-limit `TransformationError`, never a raw `RecursionError`
+  (§4.6 "Recursion budget", Roadmap R-32).
 
 ---
 

--- a/docs/proposals/transformer-recursion-depth-budget.md
+++ b/docs/proposals/transformer-recursion-depth-budget.md
@@ -1,0 +1,229 @@
+# RFC: Bounded per-level recursion budget (make self-`include` depth reachable)
+
+- **Status:** Accepted (2026-07-05) — decision recorded as Roadmap **R-32** (`accepted`); ready to
+  implement. **Awaiting implementation** (the engine change lands with the SPEC invariant + the
+  regression guard below, and only then does `transon-blockly` raise its codec depth cap).
+- **Type:** Recursion-safety fix. **Behavior-preserving for every existing template** — no output
+  changes, no error-message changes for in-range templates. It only *raises the nesting depth at
+  which the transformer stops working*, and converts a class of raw `RecursionError`s into the
+  already-documented `include` depth-limit `TransformationError`.
+- **Roadmap:** tracked as **R-32** in `docs/ROADMAP.md`.
+- **Driver:** the engine-side counterpart of a `transon-blockly` self-hosting limit. The editor
+  derives its encoder/decoder as Transon-template *projections* run by this engine (no hand-written
+  codec, `transon-blockly` AD-030). The generated codec **self-`include`s once per document node**,
+  so its reachable nesting depth is bounded by *this engine's* per-level call-stack cost — not by
+  `max_include_depth`. Today that ceiling sits below the editor's own deepest generator.
+
+## Why
+
+### Two independent depth limits, and only one is documented
+
+A running transform is bounded by **two** limits:
+
+| Limit | What it counts | How it fails |
+|---|---|---|
+| `max_include_depth` (default **50**) | *logical* nested-`include` levels | clean `TransformationError`: `include depth limit (N) exceeded: …` |
+| `sys.getrecursionlimit()` (default **1000**) | *actual* Python call-stack frames | raw `RecursionError`: `maximum recursion depth exceeded` |
+
+Only the first is in `SPECIFICATION.md`. The second is invisible — until a self-`include`ing
+template (the codec's own shape) walks deep enough that the **Python call stack overflows before
+`max_include_depth` is ever reached**. When that happens the caller gets a raw, uncatalogued
+`RecursionError` instead of the documented include-depth error, and `max_include_depth`'s nominal
+50 is fiction: a self-`include`ing template cannot get near it.
+
+### The multiplier: the `walk` / `_walk` doubling
+
+`walk()` does no work of its own — it opens the template-path context and delegates to `_walk()`
+(`transon/transformers.py`):
+
+```python
+def walk(self, template, context, path=()):
+    with self._walk_with_path(path):        # a @contextmanager
+        return self._walk(template, context, path)
+
+def _walk(self, template, context, path):
+    if isinstance(template, list):  return self.walk_list(template, context, path)
+    if isinstance(template, dict):
+        if self.marker in template: return self.walk_rule(template, context, path)
+        return self.walk_dict(template, context, path)
+    return self.walk_scalar(template, context, path)
+```
+
+So **every** descent through a template node costs a `walk` **and** a `_walk` frame where one would
+do. This is not marginal, because the codec walks a *rule at every level*. Profiling the committed
+editor encoder over a 30-deep input (peak 801 live frames) shows the recursion is dominated by a
+lockstep triple:
+
+```
+ 184  walk        ← 46% of the whole stack is the walk/_walk pair …
+ 184  _walk       ← … and exactly half of that is the redundant _walk layer
+ 184  walk_rule
+  62  rule_object
+  31  walk_param / rule_switch / transform
+  30  rule_include / rule_map / rule_cond
+```
+
+The redundant `_walk` layer alone is **184 of 801 frames — ~23% of the stack**.
+
+### Measured impact (this engine, CPython 3.x default limit 1000)
+
+- Encoding the committed editor codec over nested input hits `RecursionError` at input **depth 38**.
+- `transon-blockly`'s deepest generator, `G_encode`, is nesting **depth 41** → it cannot be loaded
+  into the editor at all; it fails as a raw stack overflow.
+- Collapsing `walk`/`_walk` (below) lifts the codec's reach **37 → 49**, and **`G_encode` (41) now
+  encodes**, with margin. A self-contained self-`include` walk template goes **57 → 75**.
+
+None of this changes any in-range template's behavior — it only moves the wall outward and makes
+the last stretch before it degrade *cleanly*.
+
+## The fix — collapse `walk` into `_walk`
+
+Fold `_walk`'s body into `walk` and set the template-path `ContextVar` inline (a `try/finally`
+instead of a `@contextmanager` generator), so one template level costs one core recursion frame:
+
+```python
+def walk(self, template, context, path=()):
+    token = _template_path.set(path)            # was: with self._walk_with_path(path):
+    try:
+        if isinstance(template, list):  return self.walk_list(template, context, path)
+        if isinstance(template, dict):
+            if self.marker in template: return self.walk_rule(template, context, path)
+            return self.walk_dict(template, context, path)
+        return self.walk_scalar(template, context, path)
+    finally:
+        _template_path.reset(token)
+```
+
+- **Behavior-identical.** The `ContextVar` is set to the same value over the same dynamic extent;
+  `walk_list` / `walk_dict` / `walk_rule` / `walk_scalar` are unchanged. `_walk_with_path` (still
+  used by `walk_rule` and `validate`) stays. Only the redundant per-node `_walk` frame is removed.
+- **No public-API change.** `walk()`'s signature and semantics are unchanged; the ~dozen `t.walk(…)`
+  call sites in `rules.py` are untouched.
+
+`walk_rule` opens its **own** `_walk_with_path(rule_path)`; inlining that too buys further headroom
+(codec reach ~70). It is **out of scope here** — the single `walk`/`_walk` collapse already clears
+the editor's deepest generator, and keeping the change minimal keeps it obviously behavior-safe.
+
+## Requirement — lock it so it can't silently degrade
+
+This fix is a stack-frame optimization, and stack-frame optimizations rot: the next refactor that
+adds a per-node wrapper, a decorator, or a helper method quietly re-doubles the cost and drops the
+reachable depth back below `G_encode` — with **no visible failure** until someone tries to load a
+deep template months later. So the fix ships **with a normative invariant and a regression guard**.
+
+### SPEC change (lands with the implementation)
+
+Add a **Recursion budget** invariant near the `include` / `max_include_depth` documentation in
+`SPECIFICATION.md` (§ describing `max_include_depth` and the `include` rule):
+
+> **Recursion budget.** Walking one level of template nesting consumes a bounded, small number of
+> Python call-stack frames — one core recursion frame per node (no `walk`/`_walk`-style doubling).
+> Because the generated `transon-blockly` editor codec self-`include`s once per document node
+> (AD-030), its reachable nesting depth is governed by this budget, not by `max_include_depth`. The
+> engine therefore transforms self-`include`ing templates at nesting depths well past the editor's
+> deepest generator (`G_encode`, depth 41) within CPython's default recursion limit (1000).
+> Exceeding `max_include_depth` MUST surface as the `include` depth-limit `TransformationError`,
+> never a raw `RecursionError`.
+
+### Regression guard (lands with the implementation)
+
+Add `tests/test_recursion_depth.py`. Two complementary guards — a **structural** one (version-robust,
+points straight at the cause) and a **black-box** one (user-facing, catches *any* per-level frame
+bloat, not just this named pair):
+
+```python
+import sys
+import inspect
+import pytest
+from transon import Transformer
+
+# R-32 — per-level recursion budget. The transon-blockly editor codec (AD-030) self-`include`s
+# once per document node; a doubled per-level frame cost overflows the host call stack with a raw
+# RecursionError before max_include_depth is reached, and makes the codec's own deepest generator
+# (G_encode, nesting depth 41) un-loadable. These guards fail if that doubling is reintroduced.
+
+WALK = {  # recurse into {"k": <child>} once per level, via self-`include`
+    "$": "switch",
+    "key": {"$": "call", "name": "type", "value": {"$": "this"}},
+    "cases": {"object": {"k": {"$": "chain", "funcs": [
+        {"$": "attr", "name": "k"},
+        {"$": "include", "name": "walk"},
+    ]}}},
+    "default": {"$": "this"},
+}
+
+def _loader(name, context=None):
+    return context.transformer(WALK) if context is not None else Transformer(WALK)
+
+def _nest(n):
+    node = "leaf"
+    for _ in range(n):
+        node = {"k": node}
+    return node
+
+# Calibrated between the pre-fix reach (~57 on CPython 3.x) and the post-fix reach (~75), ~8 levels
+# of margin each side, and comfortably above the editor codec's deepest self-`include` target
+# (G_encode, depth 41). Re-confirm on the CI matrix (3.9–3.13) when landing.
+MIN_SELF_INCLUDE_DEPTH = 65
+
+def test_self_include_reaches_min_depth_within_default_recursion_limit():
+    assert sys.getrecursionlimit() <= 1000, "guard is only meaningful at the default recursion limit"
+    t = Transformer(WALK, template_loader=_loader, max_include_depth=MIN_SELF_INCLUDE_DEPTH + 50)
+    # Must NOT raise RecursionError. Reintroducing walk/_walk doubling drops the reach below this.
+    assert t.transform(_nest(MIN_SELF_INCLUDE_DEPTH)) == "leaf"
+
+def test_exceeding_max_include_depth_is_a_clean_transformation_error_not_recursionerror():
+    # The *logical* limit must still trip first, cleanly, well inside the call-stack budget.
+    from transon import TransformationError
+    t = Transformer(WALK, template_loader=_loader, max_include_depth=10)
+    with pytest.raises(TransformationError, match=r"include depth limit \(10\) exceeded"):
+        t.transform(_nest(40))
+
+def test_no_redundant_per_node_walk_frame():
+    # Structural guard: dispatching one node must not add a `walk` -> `_walk` indirection pair.
+    frames = []
+    orig = Transformer.walk_scalar
+    def probe(self, template, context, path):
+        frames.extend(f.function for f in inspect.stack(0))
+        return orig(self, template, context, path)
+    Transformer.walk_scalar = probe
+    try:
+        Transformer(_nest(4)).transform("x")
+    finally:
+        Transformer.walk_scalar = orig
+    assert "_walk" not in frames, "walk/_walk doubling reintroduced (R-32 regression)"
+```
+
+> These three tests are **red on today's engine** and go green with the collapse — which is exactly
+> why they must be added *in the same commit as the implementation*, not before.
+
+## Rollout — a coordinated two-repo change (`transon-blockly` is engine-free)
+
+1. **This repo:** land the `walk`/`_walk` collapse + the SPEC invariant + `tests/test_recursion_depth.py`
+   in one commit; flip R-32 → `done`; changelog entry (recursion-safety, no behavior change to
+   existing templates). Bump the minor version.
+2. **`transon-blockly`** (separate change, after this ships): raise `CODEC_MAX_INCLUDE_DEPTH`
+   (`packages/editor-core/src/codec/run.ts`, currently **25**) to ~**40** — below the new ~49 wall,
+   keeping the clean `"depth limit"` guard as the backstop — and flip the self-hosting test so
+   `G_encode`/`G_decode` move from *rejected* to *loads + round-trips* (`docs/SPEC.md` §6.5,
+   `docs/traceability.md`).
+
+**Portability caveat.** `transon-blockly` runs against *any* host engine (AD-008) and in the browser
+under Pyodide (a *smaller* stack than CPython). The editor keeps **25** as its portable-safe default
+and only raises the cap for a host known to carry this fix (or gates it on engine metadata, AD-012).
+This RFC's guarantee is about *this* engine; it does not license the editor to assume it everywhere.
+
+## Out of scope (declined / deferred)
+
+- **`sys.setrecursionlimit(…)`.** Raising the interpreter limit *also* clears `G_encode`, but it
+  moves the guard rather than lowering cost, and set too high it trades a catchable `RecursionError`
+  for a hard C-stack segfault — worse on constrained hosts (Pyodide/WASM). The collapse is strictly
+  better: fewer frames helps every host. **Rejected.**
+- **Folding `walk_rule`'s own `_walk_with_path` too.** Extra headroom (~70), not needed to clear the
+  editor's deepest generator; keep this RFC minimal and obviously safe. **Deferred** — revisit only
+  if a deeper self-referential template appears.
+- **An iterative / trampolined evaluator.** A rewrite of the recursion into an explicit work-stack
+  would remove the host-stack dependency entirely, but it is a large change with real behavior risk
+  and is unjustified by the current need. **Deferred.**
+- **Raising `max_include_depth`'s default above 50.** Independent knob; not what bounds
+  self-`include`ing codecs today (the call stack is). **Out of scope.**

--- a/docs/proposals/transformer-recursion-depth-budget.md
+++ b/docs/proposals/transformer-recursion-depth-budget.md
@@ -54,7 +54,7 @@ do. This is not marginal, because the codec walks a *rule at every level*. Profi
 editor encoder over a 30-deep input (peak 801 live frames) shows the recursion is dominated by a
 lockstep triple:
 
-```
+```text
  184  walk        ← 46% of the whole stack is the walk/_walk pair …
  184  _walk       ← … and exactly half of that is the redundant _walk layer
  184  walk_rule
@@ -170,7 +170,8 @@ def test_self_include_reaches_min_depth_within_default_recursion_limit():
     assert sys.getrecursionlimit() <= 1000, "guard is only meaningful at the default recursion limit"
     t = Transformer(WALK, template_loader=_loader, max_include_depth=MIN_SELF_INCLUDE_DEPTH + 50)
     # Must NOT raise RecursionError. Reintroducing walk/_walk doubling drops the reach below this.
-    assert t.transform(_nest(MIN_SELF_INCLUDE_DEPTH)) == "leaf"
+    # WALK is an identity rebuild ({"k": <child>} in, {"k": <child>} out), so it reproduces the input.
+    assert t.transform(_nest(MIN_SELF_INCLUDE_DEPTH)) == _nest(MIN_SELF_INCLUDE_DEPTH)
 
 def test_exceeding_max_include_depth_is_a_clean_transformation_error_not_recursionerror():
     # The *logical* limit must still trip first, cleanly, well inside the call-stack budget.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "transon"
-version = "0.1.6"
+version = "0.1.7"
 description = "Homogeneous JSON template engine"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_recursion_depth.py
+++ b/tests/test_recursion_depth.py
@@ -32,7 +32,7 @@ def _nest(n):
 
 # Calibrated between the pre-fix reach (~57 on CPython 3.x) and the post-fix reach (~75), ~8 levels
 # of margin each side, and comfortably above the editor codec's deepest self-`include` target
-# (G_encode, depth 41). Re-confirm on the CI matrix (3.9–3.13) when landing.
+# (G_encode, depth 41). Re-confirm on the CI matrix (3.9-3.13) when landing.
 MIN_SELF_INCLUDE_DEPTH = 65
 
 

--- a/tests/test_recursion_depth.py
+++ b/tests/test_recursion_depth.py
@@ -1,0 +1,68 @@
+import sys
+import inspect
+import pytest
+from transon import Transformer
+
+# R-32 — per-level recursion budget. The transon-blockly editor codec (AD-030) self-`include`s
+# once per document node; a doubled per-level frame cost overflows the host call stack with a raw
+# RecursionError before max_include_depth is reached, and makes the codec's own deepest generator
+# (G_encode, nesting depth 41) un-loadable. These guards fail if that doubling is reintroduced.
+
+WALK = {  # recurse into {"k": <child>} once per level, via self-`include`
+    "$": "switch",
+    "key": {"$": "call", "name": "type", "value": {"$": "this"}},
+    "cases": {"object": {"k": {"$": "chain", "funcs": [
+        {"$": "attr", "name": "k"},
+        {"$": "include", "name": "walk"},
+    ]}}},
+    "default": {"$": "this"},
+}
+
+
+def _loader(name, context=None):
+    return context.transformer(WALK) if context is not None else Transformer(WALK)
+
+
+def _nest(n):
+    node = "leaf"
+    for _ in range(n):
+        node = {"k": node}
+    return node
+
+
+# Calibrated between the pre-fix reach (~57 on CPython 3.x) and the post-fix reach (~75), ~8 levels
+# of margin each side, and comfortably above the editor codec's deepest self-`include` target
+# (G_encode, depth 41). Re-confirm on the CI matrix (3.9–3.13) when landing.
+MIN_SELF_INCLUDE_DEPTH = 65
+
+
+def test_self_include_reaches_min_depth_within_default_recursion_limit():
+    assert sys.getrecursionlimit() <= 1000, "guard is only meaningful at the default recursion limit"
+    t = Transformer(WALK, template_loader=_loader, max_include_depth=MIN_SELF_INCLUDE_DEPTH + 50)
+    # Must NOT raise RecursionError. Reintroducing walk/_walk doubling drops the reach below this.
+    # WALK is an identity rebuild ({"k": <child>} in, {"k": <child>} out), so a completed transform
+    # reproduces the nested input — the guarantee under test is that it completes at this depth.
+    assert t.transform(_nest(MIN_SELF_INCLUDE_DEPTH)) == _nest(MIN_SELF_INCLUDE_DEPTH)
+
+
+def test_exceeding_max_include_depth_is_a_clean_transformation_error_not_recursionerror():
+    # The *logical* limit must still trip first, cleanly, well inside the call-stack budget.
+    from transon import TransformationError
+    t = Transformer(WALK, template_loader=_loader, max_include_depth=10)
+    with pytest.raises(TransformationError, match=r"include depth limit \(10\) exceeded"):
+        t.transform(_nest(40))
+
+
+def test_no_redundant_per_node_walk_frame():
+    # Structural guard: dispatching one node must not add a `walk` -> `_walk` indirection pair.
+    frames = []
+    orig = Transformer.walk_scalar
+    def probe(self, template, context, path):
+        frames.extend(f.function for f in inspect.stack(0))
+        return orig(self, template, context, path)
+    Transformer.walk_scalar = probe
+    try:
+        Transformer(_nest(4)).transform("x")
+    finally:
+        Transformer.walk_scalar = orig
+    assert "_walk" not in frames, "walk/_walk doubling reintroduced (R-32 regression)"

--- a/transon/transformers.py
+++ b/transon/transformers.py
@@ -672,17 +672,24 @@ class Transformer:
             return self.get_rule(rule_name)(self, template, context)
 
     def walk(self, template, context, path=()):
-        with self._walk_with_path(path):
-            return self._walk(template, context, path)
-
-    def _walk(self, template, context, path):
-        if isinstance(template, list):
-            return self.walk_list(template, context, path)
-        if isinstance(template, dict):
-            if self.marker in template:
-                return self.walk_rule(template, context, path)
-            return self.walk_dict(template, context, path)
-        return self.walk_scalar(template, context, path)
+        # Recursion budget (Roadmap R-32; SPECIFICATION.md "Recursion budget"): one
+        # core recursion frame per template node — no `walk`/`_walk` doubling. The
+        # template-path `ContextVar` is set inline via `try/finally` rather than a
+        # `@contextmanager` generator, so descending one nesting level costs a single
+        # stack frame. This is what lets a self-`include`ing template (the editor
+        # codec, AD-030) reach depths well past `max_include_depth` before the host
+        # call stack overflows — do not reintroduce a per-node wrapper frame here.
+        token = _template_path.set(path)
+        try:
+            if isinstance(template, list):
+                return self.walk_list(template, context, path)
+            if isinstance(template, dict):
+                if self.marker in template:
+                    return self.walk_rule(template, context, path)
+                return self.walk_dict(template, context, path)
+            return self.walk_scalar(template, context, path)
+        finally:
+            _template_path.reset(token)
 
     def write_file(self, name, content):
         self.file_writer(name, content)


### PR DESCRIPTION
Implements the accepted RFC [`docs/proposals/transformer-recursion-depth-budget.md`](docs/proposals/transformer-recursion-depth-budget.md) — Roadmap **R-32**.

## What changed

Collapsed the `walk`/`_walk` pair in the template walker into a **single core recursion frame per node**. The template-path `ContextVar` is now set inline via `try/finally` instead of a `@contextmanager` generator, so descending one level of template nesting costs one stack frame instead of two. `walk()`'s signature and public API are unchanged; `_walk_with_path` is retained (still used by `walk_rule`/`validate`).

## Why

A running transform is bounded by two limits, but only one was documented:

| Limit | Counts | Failure |
|---|---|---|
| `max_include_depth` (default 50) | logical nested-`include` levels | clean `TransformationError` |
| `sys.getrecursionlimit()` (default 1000) | actual Python call-stack frames | raw `RecursionError` |

Because the generated `transon-blockly` editor codec self-`include`s once per document node (AD-030), its reachable depth was governed by the **per-level frame cost**, not by `max_include_depth`. The redundant `_walk` frame doubled that cost, so deep self-`include`ing templates overflowed CPython's default 1000-frame stack with a raw `RecursionError` *before* the documented include-depth limit was ever reached — and the editor's deepest generator (`G_encode`, nesting depth 41) couldn't be loaded at all.

Removing the redundant per-node frame lifts the reachable self-`include` depth **57 → 75** at the default recursion limit, so `G_encode` (41) now loads and round-trips with margin.

## Behavior impact

**None for existing templates** — same output, same errors. This only moves the wall outward and converts a class of raw `RecursionError`s into the already-documented `include` depth-limit `TransformationError`.

## Locking it against silent regression

Stack-frame optimizations rot, so the fix ships with a normative invariant + a regression guard:

- **`SPECIFICATION.md` §4.6** gains a normative **Recursion budget** invariant (over-depth MUST surface as the `include` depth-limit `TransformationError`, never a raw `RecursionError`), cross-referenced in §10.
- **`tests/test_recursion_depth.py`** guards the reachable depth, the clean over-depth error, and the *absence* of the `walk`/`_walk` doubling (structural + black-box).

### Note for reviewers — one deviation from the RFC's literal test

The RFC's `test_self_include_reaches_min_depth...` asserted `== "leaf"`, but its `WALK` template is an **identity rebuild** (`{"k": <child>}` in → `{"k": <child>}` out), so that assertion was a copy bug that would stay red even post-fix. Corrected to `== _nest(MIN_SELF_INCLUDE_DEPTH)`, preserving the real guarantee under test: the transform *completes* at depth 65 without overflowing. Verified the guard genuinely bites by measuring reach with the doubling restored on the base class — **57 (pre-fix) vs 75 (post-fix)**, matching the RFC exactly.

## Verification

- New tests: 3 passed.
- Full suite: **304 passed** (behavior-preserving).
- `scripts/check_roadmap.py`: both roadmaps consistent.

## Follow-up (separate repo)

The `transon-blockly` `CODEC_MAX_INCLUDE_DEPTH` raise (25 → ~40) is intentionally left as the engine-gated follow-up the RFC describes; it lands after this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recursion safety when processing deeply nested self-includes by reducing per-level call-stack usage.
  * When the include-depth limit is exceeded, transformations now raise a clear `TransformationError` instead of a raw recursion error.
  * Increased the reachable nesting depth for valid templates.
* **Tests**
  * Added recursion-depth regression tests, including a structural guard to prevent the prior recursion pattern from returning.
* **Documentation**
  * Updated the specification, roadmap, and added an RFC describing the recursion-budget behavior and expected error semantics.
* **Chores**
  * Bumped the project version to `0.1.7` and added a new changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->