### PR TITLE
Grow the built-in function library (RFC 0007 / R-33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Built-in function library (additive published surface).** Thirty new `call` functions —
+  string helpers (`upper`/`lower`/`capitalize`/`replace`/`removeprefix`/`removesuffix`/
+  `strip`/`lstrip`/`rstrip`), `slice` (strings + arrays), epoch dates
+  (`from_epoch`/`to_epoch` with optional format), collections
+  (`length`/`flatten`/`sum`/`min`/`max`/`sorted`/`reversed`/`unique`), numerics
+  (`abs`/`floor`/`ceil`/`round`), `bool`, encoding (`b64encode`/`b64decode`),
+  deterministic `uuid5`, and regex (`regex_match`/`regex_replace`) — each wrapping
+  documented failure modes as `TransformationError` so bare `ValueError` never escapes
+  `rule_call`. New `split` rule (string → list of strings; array → list of lists;
+  `NO_CONTENT` passthrough). New total binary `in` membership operator. Spec §4.7/§4.8
+  updated; corpus examples + error-path tests. Deferred: `parse_date`, `json_*`,
+  `urlencode`, random `uuid4`/`now()`. Downstream follow-ups: `transon-authoring` refuse
+  fixtures flip + eval baseline reset; `transon-blockly` generator shrink via `in`.
+  Targets the forthcoming 0.2.0 release (held with RFC 0008). (Roadmap R-33)
+
 ## [0.1.7] - 2026-07-06
 
 ### Fixed

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -61,7 +61,7 @@
 | [R-30](#r-30-grow-the-curated-example-corpus-recipes--worked-examples) | Grow the curated example corpus (recipes + worked examples) | low | done |
 | [R-31](#r-31-normalize-exports-to-one-flat-example-corpus-name-references) | Normalize exports to one flat example corpus (name references) | medium | done |
 | [R-32](#r-32-bounded-per-level-recursion-budget-for-self-include-walks) | Bounded per-level recursion budget for self-`include` walks | medium | done |
-| [R-33](#r-33-grow-the-built-in-function-library) | Grow the built-in function library (string / numeric / collection helpers) | medium | needs-decision |
+| [R-33](#r-33-grow-the-built-in-function-library) | Grow the built-in function library (string / numeric / collection helpers) | medium | done |
 
 ---
 
@@ -992,41 +992,33 @@ listed in §10). `tests/test_recursion_depth.py` guards the reachable depth, the
 
 ### R-33. Grow the built-in function library
 
-**Status**: needs-decision · **Severity**: medium ·
+**Status**: done · **Severity**: medium ·
 **Source**: [`proposals/0007-builtin-function-library.md`](proposals/0007-builtin-function-library.md)
 
-The engine ships four functions (`str`/`int`/`float`/`type`) — structurally complete for
-transformation, but it forces two recurring costs the downstream `transon-authoring` skill has
-measured against real payloads (AWS/Stripe/GitHub). (1) **Genuine gaps become refusals**: no
-string-case, substring/prefix, or date function, so `"usd"→"USD"`, `refs/heads/main→main`, and
-`epoch→ISO` are simply impossible. (2) **Common idioms are verbose and turn-expensive**: count /
-flatten / concat are `map`+`expr` `values` reductions (and `expr` `values` raises on an empty list,
-so each needs a guard), and there is no direct `length`.
+The engine shipped four functions (`str`/`int`/`float`/`type`) — structurally complete for
+transformation, but it forced two recurring costs the downstream `transon-authoring` skill
+measured against real payloads (AWS/Stripe/GitHub). (1) **Genuine gaps became refusals**: no
+string-case, substring/prefix, or date function. (2) **Common idioms were verbose**: count /
+flatten / concat as `map`+`expr` `values` reductions, and no direct `length`.
 
-**Impact if not fixed**: real webhook/resource payloads keep hitting hard refusals for ordinary
-operations; authoring the aggregation boilerplate burns tool-turn budget at every call site.
+**Decision** (wider than the RFC's recommended Tier-1 + count/flatten/length cut):
 
-**Options** (full detail in the proposal):
+- **Tier 1 + all of Tier 2**, plus accepted Tier-3 items: `b64encode`/`b64decode`, deterministic
+  `uuid5`, and **regex now** (Python `re` dialect; ReDoS is a host responsibility — widens the
+  RFC's own "own RFC" recommendation for regex). Deferred: `parse_date`, `json_*`, `urlencode`.
+- `split` ships as a **rule** (string + array; `NO_CONTENT` passthrough), not a function.
+- Membership ships as a total binary **`in` operator**, not a `contains` function.
+- Date surface: epoch-only with format support both ways — `from_epoch(n[, fmt])` /
+  `to_epoch(s[, fmt])` (fixed ISO by default; shared locale-free directive whitelist).
+- Extra additions: `capitalize`, `slice` (strings + arrays); `reversed` also accepts strings;
+  `regex_match` returns groups-or-`null` (condition use via `bool`).
+- `min`/`max` empty policy: `TransformationError` unless an explicit `default` is supplied.
+- Release: land under `[Unreleased]` for the forthcoming **0.2.0** (held with RFC 0008
+  language-reference export); no version bump in this change alone.
 
-1. **Tier 1 + count/flatten/length subset** for a 0.2.0 minor: string helpers (`upper`/`lower`/
-   `split`/`replace`/`removeprefix`/`removesuffix`/`strip*`), epoch dates (`from_epoch`/
-   `format_epoch`), and `length`/`flatten`/`sum`. Closes the three refuse cases; collapses the
-   reduce idioms. **(Recommended)**
-2. Wider batch also pulling `min`/`max`/`sorted`/`unique`/`contains`/`round`/`bool` — defer until the
-   empty/mixed-type error policy is decided.
-3. Defer `parse_date`, `json_*`, and **regex** to their own RFCs (regex carries ReDoS + dialect
-   portability that need separate treatment).
-
-**Hard constraints (bound the list)**: functions must be **pure/deterministic** — no `now()`/
-`random`/`uuid`/I/O (the `transon-blockly` codec projections and `transon-authoring`
-`verify()`/engine-frozen fixtures all assume reproducibility); multi-arg comes free via `call`
-`values` (no rule change); and every function must keep errors inside the transon model — `rule_call`
-catches only `TypeError`, so a bare `ValueError` (e.g. `min([])`) would escape as a raw Python
-exception (the R-02 defect), meaning each must be total, take a `default`, or raise a transon error.
-Each must register a `doc` + one example (metadata visibility per R-24/R-29/R-31).
-
-**Decision**: _pending._ Open calls: 0.2.0 scope; `min`/`max`/`sorted` empty & mixed-type policy;
-epoch-only vs `parse_date`; single release vs Tier-1/Tier-2 split.
+**Shipped**: 30 new `call` functions in `transon/functions.py` (wrappers that convert documented
+failures to `TransformationError`); `split` rule in `transon/rules.py`; total `in` operator in
+`transon/operators.py`; corpus examples + error-path tests; `SPECIFICATION.md` §4.7/§4.8 updated.
 
 ---
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -26,7 +26,7 @@ producing JSON *output*. It is inspired by XSLT and JsonLogic.
 | Path | Purpose |
 |---|---|
 | `transon/transformers.py` | Engine core: `Transformer`, `Context`, `NoContent`, error types |
-| `transon/rules.py` | All 22 built-in rules, registered via `@Transformer.register_rule` |
+| `transon/rules.py` | All 23 built-in rules, registered via `@Transformer.register_rule` |
 | `transon/operators.py` | Operators for the `expr` rule (registered via `register_operator`) |
 | `transon/functions.py` | Functions for the `call` rule (registered via `register_function`) |
 | `transon/docs.py` | Documentation generator: harvests docstrings + test cases into JSON |
@@ -145,6 +145,7 @@ of a value (distinct from JSON `null`/Python `None`). Semantics:
   - `filter`: a condition evaluating to `NO_CONTENT` excludes the element.
   - `join`: items that evaluate to `NO_CONTENT` are omitted before concatenation; when
     no items remain the result is `NO_CONTENT` unless `default` is provided.
+  - `split`: when `context.this` is `NO_CONTENT`, returns `NO_CONTENT` (passthrough).
 - **`format`**: returns `NO_CONTENT` when the formatting value (or any unpacked list
   element or dict key/value) is `NO_CONTENT`, unless `default` is provided.
 - **Top-level `transform()`**: by default maps a top-level `NO_CONTENT` result to
@@ -156,7 +157,7 @@ of a value (distinct from JSON `null`/Python `None`). Semantics:
 | Exception | Meaning | Raised when |
 |---|---|---|
 | `DefinitionError` | The template is malformed | Unknown rule/operator/function name; missing required rule parameter (`Transformer.require` or `Transformer.validate()`); unknown rule parameters; ambiguous or incomplete mutually-exclusive parameter groups (`validate()`); `attr` with neither `name` nor `names`; `map` with no valid parameter combination; reserved variable name (`this`, `item`, `key`, `value`, `index`) used with `set`/`get`; iteration accessors (`item`, `key`, `value`, `index`) or `parent` used outside their valid scope; `expr`/`call` with a non-list or empty `values` parameter; non-list `chain.funcs` (`validate()`); `include` with no configured `template_loader` (default loader) |
-| `TransformationError` | The template is valid but input data is incompatible | `map`/`filter` over a non-iterable (not list/dict); `join` over mixed-type items; `attr` lookup with an incompatible index type; `zip` over non-iterable items; `expr` operator applied to incompatible operand types; `call` with incompatible argument types; `format` pattern referencing a missing key or index; `set`/`get` when a dynamic `name` evaluates to `NO_CONTENT`; `include` depth limit exceeded (nested include chain too deep) |
+| `TransformationError` | The template is valid but input data is incompatible | `map`/`filter` over a non-iterable (not list/dict); `join` over mixed-type items; `split` on a non-string/non-array input or with an invalid `sep`; `attr` lookup with an incompatible index type; `zip` over non-iterable items; `expr` operator applied to incompatible operand types; `call` with incompatible argument types or a function that rejects its arguments (e.g. empty `min`/`max`, bad epoch, invalid regex); `format` pattern referencing a missing key or index; `set`/`get` when a dynamic `name` evaluates to `NO_CONTENT`; `include` depth limit exceeded (nested include chain too deep) |
 
 Both are exported from the package root. By default, errors are raised lazily during
 `transform()` — there is no automatic validation. Opt in with `Transformer.validate()`
@@ -372,6 +373,7 @@ Other lookup failures (e.g. `TypeError` indexing a string with a string) →
 | `filter` | `cond` (required, dynamic) | Keeps elements where `cond` is truthy (and not `NO_CONTENT`). Preserves container type: list→list, dict→dict. |
 | `zip` | `items` (required, dynamic) | Transposes iterables like Python's `zip`: each output row is a **list** (`[list(row) for row in zip(*items)]`). Non-iterable items → `TransformationError`. |
 | `join` | `items` (required, dynamic), `sep` (dynamic, strings only, default `""`), `default` (optional, dynamic) | Type-homogeneous concatenation: all-strings → `sep.join`; all-lists → flatten one level; all-dicts → merged dict (later keys win). Items that evaluate to `NO_CONTENT` are omitted before concatenation. When no items remain → `NO_CONTENT` (or `default` when provided). Mixed types → `TransformationError`. `sep` must evaluate to a string when joining strings. |
+| `split` | `sep` (required, dynamic) | Inverse of string/list `join`. Input `NO_CONTENT` → `NO_CONTENT`. String input: `sep` must be a non-empty string → list of strings (empty `sep` → `TransformationError`). Array input: result is a list of lists; `sep` is a single non-array element (split on `==`) or a non-empty array (split on each contiguous subsequence occurrence). Empty-array `sep` → `TransformationError`. Because an array `sep` means subsequence, you cannot split on a separator *element* that is itself an array. Other input types → `TransformationError`. |
 | `chain` | `funcs` (required; list of templates) | Function composition: walks each template in order, each result becomes `this` of a derived context for the next. `chain(f1, f2, f3)(x) == f3(f2(f1(x)))`. |
 
 ### 4.5 Computation
@@ -402,21 +404,78 @@ Other lookup failures (e.g. `TypeError` indexing a string with a string) →
 
 ### 4.7 Built-in operators (`expr`)
 
-Each operator has a mnemonic and a code-style alias mapping to the same Python
-`operator` module function:
+Each operator has a mnemonic and a code-style alias. Most map to the Python
+`operator` module; `in` is a total membership predicate:
 
 | Mnemonic | Alias | Python impl | Note |
 |---|---|---|---|
 | `lt le eq ne ge gt` | `< <= == != >= >` | `operator.lt` … | comparisons |
 | `add sub mul div mod` | `+ - * / %` | `operator.add` …, `truediv` for `div` | `+` also concatenates strings/lists |
 | `and or not` | `&& \|\| !` | logical `and`/`or`/`not` | Python truthiness; returns operands, not always `bool` |
+| `in` | `in` | membership | **Total** (never raises). Binary `op(a, b)` = "`a` is a member of `b`": array → element membership; string → substring (`a` must be a string, else `false`); object → key presence (`a` must be a string, else `false`); any other container → `false`. |
 
 ### 4.8 Built-in functions (`call`)
 
-`str`, `int`, `float` — the Python builtins, registered directly. `type` — returns the JSON
-type name of any value (`object`/`array`/`string`/`int`/`float`/`boolean`/`null`); it is
-**total** (never raises on well-formed JSON), so it is the one operation a `switch`/`cond`
-key can safely apply to a node of unknown type.
+Existing conversion family: `str`, `int`, `float` (Python builtins), `type` (JSON type
+name — **total** over well-formed JSON), and `bool` (Python truthiness — **total**).
+
+Every other built-in is a wrapper that converts documented failure modes into
+`TransformationError` itself (`rule_call` only catches `TypeError`). Multi-argument
+forms use `call` `values`.
+
+#### Strings
+
+| name | args | notes |
+|---|---|---|
+| `upper` `lower` `capitalize` | unary | non-string → `TransformationError` |
+| `replace` | `[s, old, new]` | total on strings |
+| `removeprefix` `removesuffix` | `[s, fix]` | prefix/suffix removal (not character-set strip) |
+| `strip` `lstrip` `rstrip` | unary or `[s, chars]` | character-set trimming |
+
+#### Strings and arrays
+
+| name | args | notes |
+|---|---|---|
+| `slice` | `[x, start]` or `[x, start, stop]` | `x` string or array; Python slice semantics (negative indices, out-of-range clamps). Non-int index or other `x` type → `TransformationError`. |
+| `reversed` | unary | array → reversed array; string → reversed string; other → `TransformationError` |
+
+#### Epoch dates (UTC only)
+
+| name | args | notes |
+|---|---|---|
+| `from_epoch` | unary or `[n, fmt]` | Epoch **seconds** (int/float) → string. Default format is fixed ISO-8601 `YYYY-MM-DDThh:mm:ssZ`. Fractional seconds are **truncated**. Non-numeric / NaN / inf / out-of-range → `TransformationError`. |
+| `to_epoch` | `[s]` or `[s, fmt]` | String → epoch seconds (int). Default accepts the same fixed ISO form. Parse failure → `TransformationError`. |
+
+Shared format whitelist (locale-free, deterministic): `%Y %m %d %H %M %S %j %z %%`
+plus literal text. Any other directive (including `%a %b %c %x %X %p %Z`) →
+`TransformationError`.
+
+#### Collections and numerics
+
+| name | args | notes |
+|---|---|---|
+| `length` | unary | string / array / object → int; other → `TransformationError` |
+| `flatten` | unary | one level; non-array input or non-array element → `TransformationError` |
+| `sum` | unary | array of numbers; `sum([]) == 0`; booleans and non-numeric elements → `TransformationError` |
+| `min` `max` | `[array]` or `[array, default]` | empty without `default` → `TransformationError` |
+| `sorted` | unary | homogeneous scalars only; mixed types → `TransformationError` |
+| `unique` | unary | first-occurrence order; dict/list elements → `TransformationError` |
+| `abs` `floor` `ceil` | unary | numbers only (`math.floor`/`ceil`); non-number → `TransformationError` |
+| `round` | unary or `[x, ndigits]` | numbers only |
+
+#### Encoding, hashing, regex
+
+| name | args | notes |
+|---|---|---|
+| `b64encode` | unary | str → UTF-8 → standard-alphabet base64 str |
+| `b64decode` | unary | invalid base64 or non-UTF-8 payload → `TransformationError` |
+| `uuid5` | `[namespace, name]` | Deterministic UUID; `namespace` is `dns`/`url`/`oid`/`x500` or a UUID string. Random `uuid4` is deliberately absent (determinism). |
+| `regex_match` | `[s, pattern]` | On match: array of capture groups (`groups()`; unmatched optionals → `null`); with no groups: `[full match]`. On no match: `null`. Condition use: `bool(regex_match(...))`. Invalid pattern → `TransformationError`. |
+| `regex_replace` | `[s, pattern, repl]` | str; invalid pattern → `TransformationError` |
+
+**Regex dialect** is Python `re` (the same engine on CPython and the Pyodide reference
+host). ReDoS exposure is a **host** responsibility (e.g. per-case timeouts); the engine
+does not limit pattern complexity.
 
 ---
 

--- a/docs/proposals/0007-builtin-function-library.md
+++ b/docs/proposals/0007-builtin-function-library.md
@@ -1,9 +1,9 @@
 # RFC 0007 — Grow the built-in function library (string / numeric / collection helpers)
 
-- **Status:** Proposed — `needs-decision`
+- **Status:** Implemented — pending 0.2.0 packaging (held with RFC 0008)
 - **Created:** 2026-07-16
-- **Roadmap:** R-33 (`needs-decision`) — targets a **0.2.0** minor release
-- **Type:** Additive engine capability — every addition is a newly-named function/operator; no behavior change to existing templates
+- **Roadmap:** R-33 (`done`) — targets a **0.2.0** minor release (with RFC 0008)
+- **Type:** Additive engine capability — every addition is a newly-named function/operator/rule; no behavior change to existing templates
 - **Consumers:** `transon-authoring` (skill; pins the registry snapshot), `transon-blockly` (optional membership-predicate follow-up)
 - **Supersedes / Superseded by:** — / —
 

--- a/docs/proposals/0007-builtin-function-library.md
+++ b/docs/proposals/0007-builtin-function-library.md
@@ -1,6 +1,7 @@
 # RFC 0007 — Grow the built-in function library (string / numeric / collection helpers)
 
-- **Status:** Implemented — pending 0.2.0 packaging (held with RFC 0008)
+- **Status:** Accepted — code landed; packaging deferred to 0.2.0 (held with RFC 0008).
+  Lifecycle note: not yet `Implemented` (that term means shipped in a release per the RFC index).
 - **Created:** 2026-07-16
 - **Roadmap:** R-33 (`done`) — targets a **0.2.0** minor release (with RFC 0008)
 - **Type:** Additive engine capability — every addition is a newly-named function/operator/rule; no behavior change to existing templates

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -42,7 +42,7 @@ is the *authoritative* record of each work item's status via its **R-number**.
 | [0004](0004-editor-metadata-example-tiers.md) | Export example tags + curated example tiers | Implemented | R-29, R-30 | v0.1.5 | `transon-blockly` |
 | [0005](0005-example-corpus-normalization.md) | Normalize exports to one flat example corpus | Implemented | R-31 | v0.1.6 | docs site, `transon-blockly` |
 | [0006](0006-transformer-recursion-depth-budget.md) | Bounded per-level recursion budget (self-`include` depth) | Implemented | R-32 | v0.1.7 | `transon-blockly` |
-| [0007](0007-builtin-function-library.md) | Grow the built-in function library | Implemented | R-33 | pending 0.2.0 (with 0008) | `transon-authoring`, `transon-blockly` |
+| [0007](0007-builtin-function-library.md) | Grow the built-in function library | Accepted (code landed) | R-33 | pending 0.2.0 (with 0008) | `transon-authoring`, `transon-blockly` |
 | [0008](0008-language-reference-export.md) | Author-facing Language Reference: doc, packaging, export | Proposed | R-34, R-35, R-36 | — | `transon-authoring`, docs site |
 
 ## Adding a new RFC

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -42,7 +42,7 @@ is the *authoritative* record of each work item's status via its **R-number**.
 | [0004](0004-editor-metadata-example-tiers.md) | Export example tags + curated example tiers | Implemented | R-29, R-30 | v0.1.5 | `transon-blockly` |
 | [0005](0005-example-corpus-normalization.md) | Normalize exports to one flat example corpus | Implemented | R-31 | v0.1.6 | docs site, `transon-blockly` |
 | [0006](0006-transformer-recursion-depth-budget.md) | Bounded per-level recursion budget (self-`include` depth) | Implemented | R-32 | v0.1.7 | `transon-blockly` |
-| [0007](0007-builtin-function-library.md) | Grow the built-in function library | Proposed | R-33 | — (targets 0.2.0) | `transon-authoring`, `transon-blockly` |
+| [0007](0007-builtin-function-library.md) | Grow the built-in function library | Implemented | R-33 | pending 0.2.0 (with 0008) | `transon-authoring`, `transon-blockly` |
 | [0008](0008-language-reference-export.md) | Author-facing Language Reference: doc, packaging, export | Proposed | R-34, R-35, R-36 | — | `transon-authoring`, docs site |
 
 ## Adding a new RFC

--- a/tests/test_builtin_library.py
+++ b/tests/test_builtin_library.py
@@ -168,3 +168,86 @@ def test_no_bare_value_error_from_min():
         pass
     except ValueError:  # pragma: no cover
         pytest.fail('bare ValueError escaped rule_call')
+
+
+def test_strip_variants_and_slice_edges():
+    assert _call('strip', values=['xxhelloxx', 'x']) == 'hello'
+    assert _call('lstrip', '  hi') == 'hi'
+    assert _call('rstrip', 'hi  ') == 'hi'
+    with pytest.raises(TransformationError, match='string or array'):
+        _call('slice', values=[1, 0])
+    with pytest.raises(TransformationError, match='stop must be an int'):
+        _call('slice', values=['abc', 0, '1'])
+
+
+def test_epoch_fmt_and_range_edges():
+    with pytest.raises(TransformationError, match='must be a string'):
+        _call('from_epoch', values=[0, 1])
+    with pytest.raises(TransformationError, match='trailing'):
+        _call('from_epoch', values=[0, '%Y-%'])
+    with pytest.raises(TransformationError, match='out of range'):
+        _call('from_epoch', 10 ** 20)
+    # timezone-aware parse hits the astimezone branch
+    assert isinstance(
+        _call('to_epoch', values=['2024-01-01T00:00:00+0000', '%Y-%m-%dT%H:%M:%S%z']),
+        int,
+    )
+
+
+def test_collection_type_guards():
+    assert _call('length', {'a': 1}) == 1
+    with pytest.raises(TransformationError, match='requires an array'):
+        _call('flatten', 'nope')
+    with pytest.raises(TransformationError, match='requires an array'):
+        _call('sum', 'nope')
+    with pytest.raises(TransformationError, match='requires an array'):
+        _call('min', values=['nope'])
+    with pytest.raises(TransformationError, match='1 or 2 arguments'):
+        _call('min', values=[[1], 2, 3])
+    with pytest.raises(TransformationError, match='1 or 2 arguments'):
+        _call('max', values=[[1], 2, 3])
+    assert _call('max', values=[[1, 5, 2]]) == 5
+    assert _call('sorted', []) == []
+    with pytest.raises(TransformationError, match='requires an array'):
+        _call('sorted', 'abc')
+    with pytest.raises(TransformationError, match='scalar elements'):
+        _call('sorted', [[1], [2]])
+    with pytest.raises(TransformationError, match='requires an array'):
+        _call('unique', 'abc')
+    with pytest.raises(TransformationError, match='requires a number'):
+        _call('abs', 'x')
+    with pytest.raises(TransformationError, match='ndigits must be an int'):
+        _call('round', values=[1.5, '2'])
+    assert _call('round', 1.5) == 2
+
+
+def test_uuid5_and_regex_no_groups():
+    ns = '6ba7b810-9dad-11d1-80b4-00c04fd430c8'  # NAMESPACE_DNS
+    assert _call('uuid5', values=[ns, 'example.com']) == (
+        'cfbff0d1-9375-5685-968c-48ce8b15ae17'
+    )
+    assert _call('regex_match', values=['abc', r'b']) == ['b']
+    with pytest.raises(TransformationError, match='requires a string'):
+        _call('regex_match', values=[1, 'a'])
+    with pytest.raises(TransformationError, match='requires a string'):
+        _call('regex_replace', values=['a', 1, 'x'])
+
+
+def test_b64decode_non_utf8_payload():
+    # encode raw bytes that are not valid UTF-8
+    import base64
+    payload = base64.b64encode(b'\xff\xfe').decode('ascii')
+    with pytest.raises(TransformationError, match='not UTF-8'):
+        _call('b64decode', payload)
+
+
+def test_sorted_homogeneous_null_and_bool():
+    # Python 3 refuses to order None against None.
+    with pytest.raises(TransformationError, match='comparable'):
+        _call('sorted', [None, None])
+    assert _call('sorted', [True, False]) == [False, True]
+
+
+def test_min_incomparable_elements():
+    with pytest.raises(TransformationError, match='comparable'):
+        _call('min', values=[[1, 'a']])

--- a/tests/test_builtin_library.py
+++ b/tests/test_builtin_library.py
@@ -36,13 +36,33 @@ def _call(name, data=None, *, value=None, values=None):
 
 
 def test_upper_rejects_non_string():
-    with pytest.raises(TransformationError, match='requires a string'):
+    with pytest.raises(TransformationError, match='requires a string') as exc_info:
         _call('upper', 1)
+    assert 'at template → call' in str(exc_info.value)
 
 
-def test_split_empty_sep_raises_transformation_error():
-    with pytest.raises(TransformationError, match='non-empty string'):
-        Transformer({'$': 'split', 'sep': ''}).transform('a/b')
+def test_split_rejects_no_content_sep():
+    with pytest.raises(TransformationError, match='NO_CONTENT'):
+        Transformer(
+            {
+                '$': 'split',
+                'sep': {'$': 'get', 'name': 'missing'},
+            },
+        ).transform(['a', 'b'])
+
+
+def test_regex_match_optional_groups_all_unmatched():
+    assert _call('regex_match', values=['b', r'(a)?b']) == [None]
+
+
+def test_b64encode_rejects_surrogate():
+    with pytest.raises(TransformationError, match='UTF-8'):
+        _call('b64encode', '\ud800')
+
+
+def test_epoch_rejects_percent_space():
+    with pytest.raises(TransformationError, match='directive'):
+        _call('from_epoch', values=[0, '%Y% %m'])
 
 
 def test_split_no_content_passthrough():

--- a/tests/test_builtin_library.py
+++ b/tests/test_builtin_library.py
@@ -1,0 +1,170 @@
+import pytest
+
+from transon import Transformer, TransformationError
+from transon.docs import get_functions_docs, get_operators_docs
+
+
+NEW_FUNCTIONS = {
+    'upper', 'lower', 'capitalize', 'replace', 'removeprefix', 'removesuffix',
+    'strip', 'lstrip', 'rstrip', 'slice', 'from_epoch', 'to_epoch', 'length',
+    'flatten', 'sum', 'min', 'max', 'sorted', 'reversed', 'unique', 'abs',
+    'floor', 'ceil', 'round', 'bool', 'b64encode', 'b64decode', 'uuid5',
+    'regex_match', 'regex_replace',
+}
+
+
+def test_new_functions_present_in_docs():
+    documented = {entry['name'] for entry in get_functions_docs()}
+    assert NEW_FUNCTIONS <= documented
+    for entry in get_functions_docs():
+        if entry['name'] in NEW_FUNCTIONS:
+            assert entry['doc'] and 'TBD' not in entry['doc']
+
+
+def test_in_operator_present_in_docs():
+    names = {entry['name'] for entry in get_operators_docs()}
+    assert 'in' in names
+
+
+def _call(name, data=None, *, value=None, values=None):
+    template = {'$': 'call', 'name': name}
+    if value is not None:
+        template['value'] = value
+    if values is not None:
+        template['values'] = values
+    return Transformer(template).transform(data)
+
+
+def test_upper_rejects_non_string():
+    with pytest.raises(TransformationError, match='requires a string'):
+        _call('upper', 1)
+
+
+def test_split_empty_sep_raises_transformation_error():
+    with pytest.raises(TransformationError, match='non-empty string'):
+        Transformer({'$': 'split', 'sep': ''}).transform('a/b')
+
+
+def test_split_no_content_passthrough():
+    result = Transformer(
+        {
+            '$': 'chain',
+            'funcs': [
+                {'$': 'attr', 'name': 'missing'},
+                {'$': 'split', 'sep': '/'},
+            ],
+        },
+    ).transform({}, no_content=Transformer.NO_CONTENT)
+    assert result is Transformer.NO_CONTENT
+
+
+def test_split_rejects_non_string_non_array():
+    with pytest.raises(TransformationError, match='string or array'):
+        Transformer({'$': 'split', 'sep': '/'}).transform(1)
+
+
+def test_split_empty_array_sep_raises():
+    with pytest.raises(TransformationError, match='non-empty array'):
+        Transformer({'$': 'split', 'sep': []}).transform([1, 2])
+
+
+def test_min_empty_without_default_raises():
+    with pytest.raises(TransformationError, match='empty array'):
+        _call('min', values=[[]])
+
+
+def test_min_empty_with_default():
+    assert _call('min', values=[[], 42]) == 42
+
+
+def test_sorted_mixed_types_raises():
+    with pytest.raises(TransformationError, match='homogeneous'):
+        _call('sorted', [1, 'a'])
+
+
+def test_flatten_rejects_non_array_element():
+    with pytest.raises(TransformationError, match='every element'):
+        _call('flatten', [[1], 2])
+
+
+def test_sum_rejects_bool():
+    with pytest.raises(TransformationError, match='numeric'):
+        _call('sum', [True])
+
+
+def test_from_epoch_rejects_nan():
+    with pytest.raises(TransformationError, match='non-finite'):
+        _call('from_epoch', float('nan'))
+
+
+def test_from_epoch_rejects_locale_directive():
+    with pytest.raises(TransformationError, match='directive'):
+        _call('from_epoch', values=[0, '%Y-%b'])
+
+
+def test_to_epoch_rejects_bad_parse():
+    with pytest.raises(TransformationError, match='failed to parse'):
+        _call('to_epoch', values=['not-a-date'])
+
+
+def test_slice_rejects_non_int_index():
+    with pytest.raises(TransformationError, match='start must be an int'):
+        _call('slice', values=['abc', '1'])
+
+
+def test_unique_rejects_object_element():
+    with pytest.raises(TransformationError, match='rejects object'):
+        _call('unique', [{'a': 1}])
+
+
+def test_b64decode_invalid_raises():
+    with pytest.raises(TransformationError, match='invalid base64'):
+        _call('b64decode', '!!!')
+
+
+def test_uuid5_bad_namespace_raises():
+    with pytest.raises(TransformationError, match='namespace'):
+        _call('uuid5', values=['nope', 'x'])
+
+
+def test_regex_match_invalid_pattern_raises():
+    with pytest.raises(TransformationError, match='invalid pattern'):
+        _call('regex_match', values=['abc', '('])
+
+
+def test_regex_replace_invalid_pattern_raises():
+    with pytest.raises(TransformationError, match='invalid pattern'):
+        _call('regex_replace', values=['abc', '(', 'x'])
+
+
+def test_in_operator_is_total():
+    assert Transformer({'$': 'expr', 'op': 'in', 'value': [1, 2]}).transform(3) is False
+    assert Transformer({'$': 'expr', 'op': 'in', 'value': 'abc'}).transform(1) is False
+    assert Transformer({'$': 'expr', 'op': 'in', 'value': {'a': 1}}).transform(1) is False
+    assert Transformer({'$': 'expr', 'op': 'in', 'value': 5}).transform(1) is False
+
+
+def test_length_rejects_number():
+    with pytest.raises(TransformationError, match='string, array, or object'):
+        _call('length', 5)
+
+
+def test_reversed_rejects_object():
+    with pytest.raises(TransformationError, match='string or array'):
+        _call('reversed', {'a': 1})
+
+
+def test_from_epoch_truncates_fractional_seconds():
+    assert _call('from_epoch', 1.9) == '1970-01-01T00:00:01Z'
+
+
+def test_no_bare_value_error_from_min():
+    with pytest.raises(TransformationError):
+        _call('min', values=[[]])
+    # Ensure it is not a raw ValueError escaping the call wrapper.
+    try:
+        _call('min', values=[[]])
+    except TransformationError:
+        pass
+    except ValueError:  # pragma: no cover
+        pytest.fail('bare ValueError escaped rule_call')

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -53,6 +53,7 @@ def test_expr_op_options_resolved():
     assert op_param['kind'] == 'constant'
     assert 'lt' in op_param['options']
     assert '<' in op_param['options']
+    assert 'in' in op_param['options']
 
 
 def test_call_name_options_resolved():
@@ -65,7 +66,11 @@ def test_call_name_options_resolved():
         param for param in call['params'] if param['name'] == 'name'
     )
     assert name_param['kind'] == 'constant'
-    assert name_param['options'] == ['str', 'int', 'float', 'type']
+    assert name_param['options'] == list(Transformer._functions)
+    assert {
+        'str', 'int', 'float', 'type', 'bool', 'upper', 'length', 'from_epoch',
+        'regex_match', 'uuid5', 'b64encode',
+    } <= set(name_param['options'])
 
 
 def test_docs_payload_joins_by_name():

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -53,6 +53,7 @@ def test_get_rules():
         'zip',
         'file',
         'join',
+        'split',
         'chain',
         'expr',
         'call',

--- a/transon/functions.py
+++ b/transon/functions.py
@@ -14,7 +14,7 @@ from transon.transformers import format_error_message
 
 
 _ISO_EPOCH_FMT = '%Y-%m-%dT%H:%M:%SZ'
-_EPOCH_FMT_ALLOWED = frozenset('YmdHMSj z%')
+_EPOCH_FMT_ALLOWED = frozenset('YmdHMSjz%')
 _UUID5_NAMESPACES = {
     'dns': uuid.NAMESPACE_DNS,
     'url': uuid.NAMESPACE_URL,
@@ -318,7 +318,10 @@ def _bool(value):
 
 
 def _b64encode(value):
-    raw = _require_str(value, 'b64encode').encode('utf-8')
+    try:
+        raw = _require_str(value, 'b64encode').encode('utf-8')
+    except UnicodeEncodeError as exc:
+        _error(f'`b64encode` string is not UTF-8 encodable: {exc}')
     return base64.b64encode(raw).decode('ascii')
 
 
@@ -357,8 +360,8 @@ def _regex_match(s, pattern):
         _error(f'`regex_match` invalid pattern: {exc}')
     if match is None:
         return None
-    if match.lastindex:
-        return [g for g in match.groups()]
+    if match.re.groups:
+        return list(match.groups())
     return [match.group(0)]
 
 
@@ -534,7 +537,7 @@ Transformer.register_function(
         '(no random `uuid4`).',
 )(_uuid5)
 Transformer.register_function(
-    'regex_match', input_type='string', output_type='array',
+    'regex_match', input_type='string', output_type='array, null',
     doc='`values: [s, pattern]` — Python `re.search`. On match returns capture groups '
         'as an array (unmatched optionals are `null`); with no groups returns '
         '`[full match]`. On no match returns `null`. Use `bool(...)` in conditions. '

--- a/transon/functions.py
+++ b/transon/functions.py
@@ -164,7 +164,7 @@ def _from_epoch(n, fmt=None):
     _validate_epoch_fmt(fmt)
     try:
         return dt.strftime(fmt)
-    except (ValueError, OverflowError) as exc:
+    except (ValueError, OverflowError) as exc:  # pragma: no cover - whitelist formats succeed
         _error(f'`from_epoch` failed to format: {exc}')
 
 
@@ -259,7 +259,7 @@ def _sorted(value):
             return 'string'
         if isinstance(item, (int, float)):
             return 'number'
-        return type(item).__name__
+        return type(item).__name__  # pragma: no cover - guarded by _is_scalar
 
     kinds = {_kind(item) for item in value}
     if len(kinds) > 1:

--- a/transon/functions.py
+++ b/transon/functions.py
@@ -1,8 +1,48 @@
+import base64
+import binascii
+import math
+import re
+import uuid
+from datetime import datetime, timezone
+
 from transon import (
     Transformer,
     DefinitionError,
+    TransformationError,
 )
 from transon.transformers import format_error_message
+
+
+_ISO_EPOCH_FMT = '%Y-%m-%dT%H:%M:%SZ'
+_EPOCH_FMT_ALLOWED = frozenset('YmdHMSj z%')
+_UUID5_NAMESPACES = {
+    'dns': uuid.NAMESPACE_DNS,
+    'url': uuid.NAMESPACE_URL,
+    'oid': uuid.NAMESPACE_OID,
+    'x500': uuid.NAMESPACE_X500,
+}
+
+
+def _error(message):
+    raise TransformationError(format_error_message(message))
+
+
+def _require_str(value, name):
+    if not isinstance(value, str):
+        _error(f'`{name}` requires a string, got {type(value).__name__}')
+    return value
+
+
+def _require_number(value, name):
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        _error(f'`{name}` requires a number, got {type(value).__name__}')
+    if isinstance(value, float) and (math.isnan(value) or math.isinf(value)):
+        _error(f'`{name}` rejects non-finite number {value!r}')
+    return value
+
+
+def _is_scalar(value):
+    return value is None or isinstance(value, (bool, int, float, str))
 
 
 def _json_type(value):
@@ -30,6 +70,308 @@ def _json_type(value):
     ))
 
 
+def _upper(value):
+    return _require_str(value, 'upper').upper()
+
+
+def _lower(value):
+    return _require_str(value, 'lower').lower()
+
+
+def _capitalize(value):
+    return _require_str(value, 'capitalize').capitalize()
+
+
+def _replace(s, old, new):
+    return _require_str(s, 'replace').replace(
+        _require_str(old, 'replace'),
+        _require_str(new, 'replace'),
+    )
+
+
+def _removeprefix(s, prefix):
+    return _require_str(s, 'removeprefix').removeprefix(
+        _require_str(prefix, 'removeprefix')
+    )
+
+
+def _removesuffix(s, suffix):
+    return _require_str(s, 'removesuffix').removesuffix(
+        _require_str(suffix, 'removesuffix')
+    )
+
+
+def _strip(s, chars=None):
+    s = _require_str(s, 'strip')
+    if chars is None:
+        return s.strip()
+    return s.strip(_require_str(chars, 'strip'))
+
+
+def _lstrip(s, chars=None):
+    s = _require_str(s, 'lstrip')
+    if chars is None:
+        return s.lstrip()
+    return s.lstrip(_require_str(chars, 'lstrip'))
+
+
+def _rstrip(s, chars=None):
+    s = _require_str(s, 'rstrip')
+    if chars is None:
+        return s.rstrip()
+    return s.rstrip(_require_str(chars, 'rstrip'))
+
+
+def _slice(x, start, stop=None):
+    if not isinstance(x, (str, list)):
+        _error(f'`slice` requires a string or array, got {type(x).__name__}')
+    if isinstance(start, bool) or not isinstance(start, int):
+        _error(f'`slice` start must be an int, got {type(start).__name__}')
+    if stop is None:
+        return x[start:]
+    if isinstance(stop, bool) or not isinstance(stop, int):
+        _error(f'`slice` stop must be an int, got {type(stop).__name__}')
+    return x[start:stop]
+
+
+def _validate_epoch_fmt(fmt):
+    if not isinstance(fmt, str):
+        _error(f'epoch format must be a string, got {type(fmt).__name__}')
+    i = 0
+    while i < len(fmt):
+        if fmt[i] != '%':
+            i += 1
+            continue
+        if i + 1 >= len(fmt):
+            _error(f'epoch format has a trailing `%`: {fmt!r}')
+        directive = fmt[i + 1]
+        if directive not in _EPOCH_FMT_ALLOWED:
+            _error(
+                f'epoch format rejects locale-sensitive or unsupported directive '
+                f'`%{directive}` in {fmt!r}'
+            )
+        i += 2
+
+
+def _from_epoch(n, fmt=None):
+    n = _require_number(n, 'from_epoch')
+    try:
+        dt = datetime.fromtimestamp(int(n), tz=timezone.utc)
+    except (OverflowError, OSError, ValueError):
+        _error(f'`from_epoch` epoch seconds out of range: {n!r}')
+    if fmt is None:
+        return dt.strftime(_ISO_EPOCH_FMT)
+    _validate_epoch_fmt(fmt)
+    try:
+        return dt.strftime(fmt)
+    except (ValueError, OverflowError) as exc:
+        _error(f'`from_epoch` failed to format: {exc}')
+
+
+def _to_epoch(s, fmt=None):
+    s = _require_str(s, 'to_epoch')
+    if fmt is None:
+        fmt = _ISO_EPOCH_FMT
+    else:
+        _validate_epoch_fmt(fmt)
+    try:
+        dt = datetime.strptime(s, fmt)
+    except ValueError as exc:
+        _error(f'`to_epoch` failed to parse {s!r} with format {fmt!r}: {exc}')
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+    return int(dt.timestamp())
+
+
+def _length(value):
+    if isinstance(value, (str, list, dict)):
+        return len(value)
+    _error(f'`length` requires a string, array, or object, got {type(value).__name__}')
+
+
+def _flatten(value):
+    if not isinstance(value, list):
+        _error(f'`flatten` requires an array, got {type(value).__name__}')
+    result = []
+    for item in value:
+        if not isinstance(item, list):
+            _error('`flatten` requires every element to be an array')
+        result.extend(item)
+    return result
+
+
+def _sum(value):
+    if not isinstance(value, list):
+        _error(f'`sum` requires an array, got {type(value).__name__}')
+    total = 0
+    for item in value:
+        if isinstance(item, bool) or not isinstance(item, (int, float)):
+            _error(f'`sum` requires numeric elements, got {type(item).__name__}')
+        total += item
+    return total
+
+
+def _min_max(name, array, default=None, *, has_default=False):
+    if not isinstance(array, list):
+        _error(f'`{name}` requires an array, got {type(array).__name__}')
+    if not array:
+        if has_default:
+            return default
+        _error(f'`{name}` of an empty array requires a default')
+    try:
+        return (min if name == 'min' else max)(array)
+    except TypeError:
+        _error(f'`{name}` requires comparable homogeneous elements')
+
+
+def _min_call(*args):
+    if len(args) == 1:
+        return _min_max('min', args[0], has_default=False)
+    if len(args) == 2:
+        return _min_max('min', args[0], args[1], has_default=True)
+    _error(f'`min` expects 1 or 2 arguments, got {len(args)}')
+
+
+def _max_call(*args):
+    if len(args) == 1:
+        return _min_max('max', args[0], has_default=False)
+    if len(args) == 2:
+        return _min_max('max', args[0], args[1], has_default=True)
+    _error(f'`max` expects 1 or 2 arguments, got {len(args)}')
+
+
+def _sorted(value):
+    if not isinstance(value, list):
+        _error(f'`sorted` requires an array, got {type(value).__name__}')
+    if not value:
+        return []
+    if not all(_is_scalar(item) for item in value):
+        _error('`sorted` requires scalar elements')
+
+    def _kind(item):
+        if item is None:
+            return 'null'
+        if isinstance(item, bool):
+            return 'boolean'
+        if isinstance(item, str):
+            return 'string'
+        if isinstance(item, (int, float)):
+            return 'number'
+        return type(item).__name__
+
+    kinds = {_kind(item) for item in value}
+    if len(kinds) > 1:
+        _error('`sorted` requires homogeneous scalar types')
+    try:
+        return sorted(value)
+    except TypeError:
+        _error('`sorted` requires comparable homogeneous elements')
+
+
+def _reversed(value):
+    if isinstance(value, list):
+        return list(reversed(value))
+    if isinstance(value, str):
+        return value[::-1]
+    _error(f'`reversed` requires a string or array, got {type(value).__name__}')
+
+
+def _unique(value):
+    if not isinstance(value, list):
+        _error(f'`unique` requires an array, got {type(value).__name__}')
+    seen = set()
+    result = []
+    for item in value:
+        if isinstance(item, (dict, list)):
+            _error('`unique` rejects object or array elements')
+        if item not in seen:
+            seen.add(item)
+            result.append(item)
+    return result
+
+
+def _abs(value):
+    return abs(_require_number(value, 'abs'))
+
+
+def _floor(value):
+    return math.floor(_require_number(value, 'floor'))
+
+
+def _ceil(value):
+    return math.ceil(_require_number(value, 'ceil'))
+
+
+def _round(value, ndigits=None):
+    value = _require_number(value, 'round')
+    if ndigits is None:
+        return round(value)
+    if isinstance(ndigits, bool) or not isinstance(ndigits, int):
+        _error(f'`round` ndigits must be an int, got {type(ndigits).__name__}')
+    return round(value, ndigits)
+
+
+def _bool(value):
+    return bool(value)
+
+
+def _b64encode(value):
+    raw = _require_str(value, 'b64encode').encode('utf-8')
+    return base64.b64encode(raw).decode('ascii')
+
+
+def _b64decode(value):
+    s = _require_str(value, 'b64decode')
+    try:
+        raw = base64.b64decode(s, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        _error(f'`b64decode` invalid base64: {exc}')
+    try:
+        return raw.decode('utf-8')
+    except UnicodeDecodeError as exc:
+        _error(f'`b64decode` payload is not UTF-8: {exc}')
+
+
+def _uuid5(namespace, name):
+    name = _require_str(name, 'uuid5')
+    if isinstance(namespace, str) and namespace in _UUID5_NAMESPACES:
+        ns = _UUID5_NAMESPACES[namespace]
+    else:
+        try:
+            ns = uuid.UUID(_require_str(namespace, 'uuid5'))
+        except (ValueError, AttributeError, TypeError):
+            _error(
+                '`uuid5` namespace must be one of dns/url/oid/x500 or a UUID string'
+            )
+    return str(uuid.uuid5(ns, name))
+
+
+def _regex_match(s, pattern):
+    s = _require_str(s, 'regex_match')
+    pattern = _require_str(pattern, 'regex_match')
+    try:
+        match = re.search(pattern, s)
+    except re.error as exc:
+        _error(f'`regex_match` invalid pattern: {exc}')
+    if match is None:
+        return None
+    if match.lastindex:
+        return [g for g in match.groups()]
+    return [match.group(0)]
+
+
+def _regex_replace(s, pattern, repl):
+    s = _require_str(s, 'regex_replace')
+    pattern = _require_str(pattern, 'regex_replace')
+    repl = _require_str(repl, 'regex_replace')
+    try:
+        return re.sub(pattern, repl, s)
+    except re.error as exc:
+        _error(f'`regex_replace` invalid pattern: {exc}')
+
+
 Transformer.register_function(
     'str', input_type='any', output_type='str',
     doc='Convert any value to its string representation (Python `str`).',
@@ -49,3 +391,158 @@ Transformer.register_function(
         '`float`, `boolean`, or `null`. Total — never raises on well-formed JSON, so it '
         'is the one operation a `switch`/`cond` key can safely apply to an unknown node.',
 )(_json_type)
+Transformer.register_function(
+    'bool', input_type='any', output_type='boolean',
+    doc='Convert any value to a boolean by Python truthiness. Total — never raises. '
+        'Useful to turn `regex_match` (groups-or-null) into a condition predicate.',
+)(_bool)
+
+Transformer.register_function(
+    'upper', input_type='string', output_type='string',
+    doc='Return `s` uppercased. Non-string input raises `TransformationError`.',
+)(_upper)
+Transformer.register_function(
+    'lower', input_type='string', output_type='string',
+    doc='Return `s` lowercased. Non-string input raises `TransformationError`.',
+)(_lower)
+Transformer.register_function(
+    'capitalize', input_type='string', output_type='string',
+    doc='Return `s` with the first character uppercased and the rest lowercased. '
+        'Non-string input raises `TransformationError`.',
+)(_capitalize)
+Transformer.register_function(
+    'replace', input_type='string', output_type='string',
+    doc='`values: [s, old, new]` — replace all occurrences of `old` with `new` in `s`.',
+)(_replace)
+Transformer.register_function(
+    'removeprefix', input_type='string', output_type='string',
+    doc='`values: [s, prefix]` — remove `prefix` from the start of `s` if present. '
+        'Unlike `lstrip`, this is exact-prefix removal, not character-set trimming.',
+)(_removeprefix)
+Transformer.register_function(
+    'removesuffix', input_type='string', output_type='string',
+    doc='`values: [s, suffix]` — remove `suffix` from the end of `s` if present. '
+        'Unlike `rstrip`, this is exact-suffix removal, not character-set trimming.',
+)(_removesuffix)
+Transformer.register_function(
+    'strip', input_type='string', output_type='string',
+    doc='Strip leading/trailing whitespace, or `values: [s, chars]` for a character set. '
+        'Not a substitute for `removeprefix`/`removesuffix`.',
+)(_strip)
+Transformer.register_function(
+    'lstrip', input_type='string', output_type='string',
+    doc='Strip leading whitespace, or `values: [s, chars]` for a character set.',
+)(_lstrip)
+Transformer.register_function(
+    'rstrip', input_type='string', output_type='string',
+    doc='Strip trailing whitespace, or `values: [s, chars]` for a character set.',
+)(_rstrip)
+
+Transformer.register_function(
+    'slice', input_type='string, array', output_type='string, array',
+    doc='`values: [x, start]` or `[x, start, stop]` — Python slice of a string or array. '
+        'Negative indices and out-of-range clamps apply. Non-int indices raise '
+        '`TransformationError`.',
+)(_slice)
+
+Transformer.register_function(
+    'from_epoch', input_type='number', output_type='string',
+    doc='Convert epoch **seconds** (int/float; fractional truncated) to a UTC string. '
+        'Unary form uses fixed ISO-8601 `YYYY-MM-DDThh:mm:ssZ`. '
+        '`values: [n, fmt]` uses an explicit format restricted to '
+        '`%Y %m %d %H %M %S %j %z %%` plus literal text. Non-finite or out-of-range '
+        'inputs and disallowed directives raise `TransformationError`.',
+)(_from_epoch)
+Transformer.register_function(
+    'to_epoch', input_type='string', output_type='int',
+    doc='Parse a UTC date/time string to epoch seconds (int). '
+        '`values: [s]` accepts fixed ISO-8601 `YYYY-MM-DDThh:mm:ssZ`; '
+        '`values: [s, fmt]` uses an explicit format with the same whitelist as '
+        '`from_epoch`. Parse failure raises `TransformationError`.',
+)(_to_epoch)
+
+Transformer.register_function(
+    'length', input_type='string, array, object', output_type='int',
+    doc='Return the length of a string, array, or object. Other types raise '
+        '`TransformationError`.',
+)(_length)
+Transformer.register_function(
+    'flatten', input_type='array', output_type='array',
+    doc='Flatten one level of an array-of-arrays. Non-array input or a non-array '
+        'element raises `TransformationError`.',
+)(_flatten)
+Transformer.register_function(
+    'sum', input_type='array', output_type='number',
+    doc='Sum an array of numbers. `sum([])` is `0`. Booleans and non-numeric elements '
+        'raise `TransformationError`.',
+)(_sum)
+Transformer.register_function(
+    'min', input_type='array', output_type='any',
+    doc='`values: [array]` or `[array, default]` — minimum element. Empty array without '
+        '`default` raises `TransformationError`.',
+)(_min_call)
+Transformer.register_function(
+    'max', input_type='array', output_type='any',
+    doc='`values: [array]` or `[array, default]` — maximum element. Empty array without '
+        '`default` raises `TransformationError`.',
+)(_max_call)
+Transformer.register_function(
+    'sorted', input_type='array', output_type='array',
+    doc='Return a new array of homogeneous scalars sorted ascending. Mixed types raise '
+        '`TransformationError`.',
+)(_sorted)
+Transformer.register_function(
+    'reversed', input_type='string, array', output_type='string, array',
+    doc='Reverse an array or a string. Other types raise `TransformationError`.',
+)(_reversed)
+Transformer.register_function(
+    'unique', input_type='array', output_type='array',
+    doc='Deduplicate an array preserving first-occurrence order. Object or array '
+        'elements raise `TransformationError`.',
+)(_unique)
+Transformer.register_function(
+    'abs', input_type='number', output_type='number',
+    doc='Absolute value of a number. Non-number raises `TransformationError`.',
+)(_abs)
+Transformer.register_function(
+    'floor', input_type='number', output_type='int',
+    doc='Floor of a number (`math.floor`). Non-number raises `TransformationError`.',
+)(_floor)
+Transformer.register_function(
+    'ceil', input_type='number', output_type='int',
+    doc='Ceiling of a number (`math.ceil`). Non-number raises `TransformationError`.',
+)(_ceil)
+Transformer.register_function(
+    'round', input_type='number', output_type='number',
+    doc='Round a number; optional `values: [x, ndigits]`. Non-number raises '
+        '`TransformationError`.',
+)(_round)
+
+Transformer.register_function(
+    'b64encode', input_type='string', output_type='string',
+    doc='UTF-8 encode a string and return standard-alphabet base64.',
+)(_b64encode)
+Transformer.register_function(
+    'b64decode', input_type='string', output_type='string',
+    doc='Decode standard-alphabet base64 to a UTF-8 string. Invalid base64 or '
+        'non-UTF-8 payload raises `TransformationError`.',
+)(_b64decode)
+Transformer.register_function(
+    'uuid5', input_type='string', output_type='string',
+    doc='`values: [namespace, name]` — deterministic UUID5. `namespace` is one of '
+        '`dns`/`url`/`oid`/`x500` or a UUID string. Pure and reproducible '
+        '(no random `uuid4`).',
+)(_uuid5)
+Transformer.register_function(
+    'regex_match', input_type='string', output_type='array',
+    doc='`values: [s, pattern]` — Python `re.search`. On match returns capture groups '
+        'as an array (unmatched optionals are `null`); with no groups returns '
+        '`[full match]`. On no match returns `null`. Use `bool(...)` in conditions. '
+        'Invalid pattern raises `TransformationError`. Dialect is Python `re`; ReDoS '
+        'is a host responsibility.',
+)(_regex_match)
+Transformer.register_function(
+    'regex_replace', input_type='string', output_type='string',
+    doc='`values: [s, pattern, repl]` — Python `re.sub`. Invalid pattern raises '
+        '`TransformationError`. Dialect is Python `re`; ReDoS is a host responsibility.',
+)(_regex_replace)

--- a/transon/operators.py
+++ b/transon/operators.py
@@ -71,3 +71,23 @@ Transformer.register_operator(
     '!', 'not', kind='unary', types='boolean', result='boolean',
     doc='Logical negation (Python `not`).',
 )(operator.not_)
+
+
+def _in(a, b):
+    """Total membership: is ``a`` a member of ``b``? Never raises."""
+    if isinstance(b, list):
+        return a in b
+    if isinstance(b, str):
+        return isinstance(a, str) and a in b
+    if isinstance(b, dict):
+        return isinstance(a, str) and a in b
+    return False
+
+
+Transformer.register_operator(
+    'in', 'in', kind='binary', types='any', result='boolean',
+    doc='Membership: `true` when the left operand is a member of the right. '
+        'Array → element membership; string → substring (left must be a string, '
+        'else `false`); object → key presence (left must be a string, else `false`); '
+        'any other container → `false`. Total — never raises.',
+)(_in)

--- a/transon/rules.py
+++ b/transon/rules.py
@@ -513,6 +513,8 @@ def rule_split(t: Transformer, template, context: Context):
     if value is t.NO_CONTENT:
         return t.NO_CONTENT
     sep = t.walk_param(t.require(template, 'sep'), context, 'sep')
+    if sep is t.NO_CONTENT:
+        t.transformation_error('`sep` must not evaluate to `NO_CONTENT`')
     if isinstance(value, str):
         if not isinstance(sep, str) or sep == '':
             t.transformation_error(
@@ -729,7 +731,7 @@ def rule_expr(t: Transformer, template, context: Context):
     | b64encode     | string               | string         |
     | b64decode     | string               | string         |
     | uuid5         | string               | string         |
-    | regex_match   | string               | array          |
+    | regex_match   | string               | array, null    |
     | regex_replace | string               | string         |
 
 """,

--- a/transon/rules.py
+++ b/transon/rules.py
@@ -624,6 +624,7 @@ def rule_chain(t: Transformer, template, context: Context):
     | &&           | and         | binary | any            | any            |
     | &#124;&#124; | or          | binary | any            | any            |
     | !            | not         | unary  | boolean        | boolean        |
+    | in           | in          | binary | any            | boolean        |
 
     You can use code-style or mnemonic name (i.e. operator or alternative). 
 """,
@@ -694,12 +695,42 @@ def rule_expr(t: Transformer, template, context: Context):
     
     ###### Possible values:
 
-    | name  | input | output |
-    |-------|:-----:|:------:|
-    | str   |  any  |  str   | 
-    | int   |  str  |  int   | 
-    | float |  str  | float  | 
-    | type  |  any  | string | 
+    | name          | input                | output         |
+    |---------------|:--------------------:|:--------------:|
+    | str           | any                  | str            |
+    | int           | str                  | int            |
+    | float         | str                  | float          |
+    | type          | any                  | string         |
+    | bool          | any                  | boolean        |
+    | upper         | string               | string         |
+    | lower         | string               | string         |
+    | capitalize    | string               | string         |
+    | replace       | string               | string         |
+    | removeprefix  | string               | string         |
+    | removesuffix  | string               | string         |
+    | strip         | string               | string         |
+    | lstrip        | string               | string         |
+    | rstrip        | string               | string         |
+    | slice         | string, array        | string, array  |
+    | from_epoch    | number               | string         |
+    | to_epoch      | string               | int            |
+    | length        | string, array, object| int            |
+    | flatten       | array                | array          |
+    | sum           | array                | number         |
+    | min           | array                | any            |
+    | max           | array                | any            |
+    | sorted        | array                | array          |
+    | reversed      | string, array        | string, array  |
+    | unique        | array                | array          |
+    | abs           | number               | number         |
+    | floor         | number               | int            |
+    | ceil          | number               | int            |
+    | round         | number               | number         |
+    | b64encode     | string               | string         |
+    | b64decode     | string               | string         |
+    | uuid5         | string               | string         |
+    | regex_match   | string               | array          |
+    | regex_replace | string               | string         |
 
 """,
     value="Defines template for single parameter value",

--- a/transon/rules.py
+++ b/transon/rules.py
@@ -488,6 +488,81 @@ def rule_join(t: Transformer, template, context: Context):
 
 
 @Transformer.register_rule(
+    'split',
+    _variants=[{'sep'}],
+    sep="Separator used to split the current context value. Can be dynamic. "
+        "For a string input must evaluate to a non-empty string. For an array "
+        "input may be a single non-array element (split on `==`) or a non-empty "
+        "array (split on each contiguous subsequence). Empty string/array `sep` "
+        "raises `TransformationError`.",
+)
+def rule_split(t: Transformer, template, context: Context):
+    """
+    Splits a string or an array on a separator — the inverse of string/list `join`.
+
+    - String input → list of strings. `sep` must be a non-empty string.
+    - Array input → list of lists. `sep` is either a single non-array element
+      (split where elements equal `sep`) or a non-empty array (split on each
+      contiguous occurrence of that subsequence). Because an array `sep` means
+      subsequence, you cannot split on a separator *element* that is itself an
+      array.
+    - `NO_CONTENT` input → `NO_CONTENT`.
+    - Any other input type → `TransformationError`.
+    """
+    value = context.this
+    if value is t.NO_CONTENT:
+        return t.NO_CONTENT
+    sep = t.walk_param(t.require(template, 'sep'), context, 'sep')
+    if isinstance(value, str):
+        if not isinstance(sep, str) or sep == '':
+            t.transformation_error(
+                '`sep` must evaluate to a non-empty string for string split'
+            )
+        return value.split(sep)
+    if isinstance(value, list):
+        if isinstance(sep, list):
+            if not sep:
+                t.transformation_error(
+                    '`sep` must be a non-empty array when used as a subsequence'
+                )
+            return _split_array_subsequence(value, sep)
+        return _split_array_element(value, sep)
+    t.transformation_error(
+        f'`split` requires a string or array, got {type(value).__name__}'
+    )
+
+
+def _split_array_element(items, sep):
+    result = []
+    current = []
+    for item in items:
+        if item == sep:
+            result.append(current)
+            current = []
+        else:
+            current.append(item)
+    result.append(current)
+    return result
+
+
+def _split_array_subsequence(items, sep):
+    result = []
+    current = []
+    n = len(sep)
+    i = 0
+    while i < len(items):
+        if items[i:i + n] == sep:
+            result.append(current)
+            current = []
+            i += n
+        else:
+            current.append(items[i])
+            i += 1
+    result.append(current)
+    return result
+
+
+@Transformer.register_rule(
     'chain',
     _variants=[{'funcs'}],
     _containers={'funcs': ContainerType.LIST},

--- a/transon/tests/test_functions_collection.py
+++ b/transon/tests/test_functions_collection.py
@@ -1,0 +1,143 @@
+from . import base
+
+
+class LengthOfString(base.TableDataBaseCase):
+    """
+    Returns the length of a string with `length`.
+    """
+    tags = ['call', 'func:length']
+    template = {'$': 'call', 'name': 'length'}
+    data = 'hello'
+    result = 5
+
+
+class LengthOfArray(base.TableDataBaseCase):
+    """
+    Returns the length of an array with `length`.
+    """
+    tags = ['call', 'func:length']
+    template = {'$': 'call', 'name': 'length'}
+    data = [1, 2, 3]
+    result = 3
+
+
+class FlattenOneLevel(base.TableDataBaseCase):
+    """
+    Flattens one level of an array-of-arrays with `flatten`.
+    """
+    tags = ['call', 'func:flatten']
+    template = {'$': 'call', 'name': 'flatten'}
+    data = [[1, 2], [3], [4, 5]]
+    result = [1, 2, 3, 4, 5]
+
+
+class SumNumbers(base.TableDataBaseCase):
+    """
+    Sums an array of numbers with `sum` (`sum([])` is `0`).
+    """
+    tags = ['call', 'func:sum']
+    template = {'$': 'call', 'name': 'sum'}
+    data = [1, 2, 3.5]
+    result = 6.5
+
+
+class MinOfArray(base.TableDataBaseCase):
+    """
+    Returns the minimum element of an array with `min`.
+    """
+    tags = ['call:values', 'func:min']
+    template = {
+        '$': 'call',
+        'name': 'min',
+        'values': [{'$': 'this'}],
+    }
+    data = [3, 1, 2]
+    result = 1
+
+
+class MaxWithDefault(base.TableDataBaseCase):
+    """
+    Returns the provided default when `max` is called on an empty array.
+    """
+    tags = ['call:values', 'func:max']
+    template = {
+        '$': 'call',
+        'name': 'max',
+        'values': [{'$': 'this'}, 0],
+    }
+    data = []
+    result = 0
+
+
+class SortedArray(base.TableDataBaseCase):
+    """
+    Returns a new ascending-sorted array of homogeneous scalars with `sorted`.
+    """
+    tags = ['call', 'func:sorted']
+    template = {'$': 'call', 'name': 'sorted'}
+    data = [3, 1, 2]
+    result = [1, 2, 3]
+
+
+class UniquePreserveOrder(base.TableDataBaseCase):
+    """
+    Deduplicates an array while preserving first-occurrence order with `unique`.
+    """
+    tags = ['call', 'func:unique']
+    template = {'$': 'call', 'name': 'unique'}
+    data = ['a', 'b', 'a', 'c', 'b']
+    result = ['a', 'b', 'c']
+
+
+class AbsNumber(base.TableDataBaseCase):
+    """
+    Returns the absolute value of a number with `abs`.
+    """
+    tags = ['call', 'func:abs']
+    template = {'$': 'call', 'name': 'abs'}
+    data = -7
+    result = 7
+
+
+class FloorNumber(base.TableDataBaseCase):
+    """
+    Returns the floor of a number with `floor`.
+    """
+    tags = ['call', 'func:floor']
+    template = {'$': 'call', 'name': 'floor'}
+    data = 3.7
+    result = 3
+
+
+class CeilNumber(base.TableDataBaseCase):
+    """
+    Returns the ceiling of a number with `ceil`.
+    """
+    tags = ['call', 'func:ceil']
+    template = {'$': 'call', 'name': 'ceil'}
+    data = 3.2
+    result = 4
+
+
+class RoundWithDigits(base.TableDataBaseCase):
+    """
+    Rounds a number to a given number of digits with `round`.
+    """
+    tags = ['call:values', 'func:round']
+    template = {
+        '$': 'call',
+        'name': 'round',
+        'values': [{'$': 'this'}, 2],
+    }
+    data = 3.14159
+    result = 3.14
+
+
+class BoolOfNull(base.TableDataBaseCase):
+    """
+    Converts a value to a boolean by Python truthiness with `bool` (total).
+    """
+    tags = ['call', 'func:bool']
+    template = {'$': 'call', 'name': 'bool'}
+    data = None
+    result = False

--- a/transon/tests/test_functions_date.py
+++ b/transon/tests/test_functions_date.py
@@ -1,0 +1,53 @@
+from . import base
+
+
+class FromEpochIso(base.TableDataBaseCase):
+    """
+    Converts epoch seconds to a fixed ISO-8601 UTC timestamp with `from_epoch`.
+    """
+    tags = ['call', 'func:from_epoch']
+    template = {'$': 'call', 'name': 'from_epoch'}
+    data = 1712345678
+    result = '2024-04-05T19:34:38Z'
+
+
+class FromEpochCustomFormat(base.TableDataBaseCase):
+    """
+    Formats epoch seconds with an explicit whitelist format via `from_epoch`.
+    """
+    tags = ['call:values', 'func:from_epoch']
+    template = {
+        '$': 'call',
+        'name': 'from_epoch',
+        'values': [{'$': 'this'}, '%Y-%m-%d'],
+    }
+    data = 1712345678
+    result = '2024-04-05'
+
+
+class ToEpochIso(base.TableDataBaseCase):
+    """
+    Parses a fixed ISO-8601 UTC timestamp to epoch seconds with `to_epoch`.
+    """
+    tags = ['call:values', 'func:to_epoch']
+    template = {
+        '$': 'call',
+        'name': 'to_epoch',
+        'values': [{'$': 'this'}],
+    }
+    data = '2024-04-05T19:34:38Z'
+    result = 1712345678
+
+
+class ToEpochCustomFormat(base.TableDataBaseCase):
+    """
+    Parses a custom-format UTC date string to epoch seconds with `to_epoch`.
+    """
+    tags = ['call:values', 'func:to_epoch']
+    template = {
+        '$': 'call',
+        'name': 'to_epoch',
+        'values': [{'$': 'this'}, '%Y-%m-%dT%H:%M:%S'],
+    }
+    data = '2024-04-05T19:34:38'
+    result = 1712345678

--- a/transon/tests/test_functions_encoding.py
+++ b/transon/tests/test_functions_encoding.py
@@ -1,0 +1,77 @@
+from . import base
+
+
+class B64Encode(base.TableDataBaseCase):
+    """
+    Encodes a UTF-8 string as standard-alphabet base64 with `b64encode`.
+    """
+    tags = ['call', 'func:b64encode']
+    template = {'$': 'call', 'name': 'b64encode'}
+    data = 'hi'
+    result = 'aGk='
+
+
+class B64Decode(base.TableDataBaseCase):
+    """
+    Decodes standard-alphabet base64 to a UTF-8 string with `b64decode`.
+    """
+    tags = ['call', 'func:b64decode']
+    template = {'$': 'call', 'name': 'b64decode'}
+    data = 'aGk='
+    result = 'hi'
+
+
+class Uuid5Dns(base.TableDataBaseCase):
+    """
+    Builds a deterministic UUID5 from a well-known namespace and a name.
+    """
+    tags = ['call:values', 'func:uuid5']
+    template = {
+        '$': 'call',
+        'name': 'uuid5',
+        'values': ['dns', 'example.com'],
+    }
+    data = None
+    result = 'cfbff0d1-9375-5685-968c-48ce8b15ae17'
+
+
+class RegexMatchGroups(base.TableDataBaseCase):
+    """
+    Returns capture groups from `regex_match` on a successful match.
+    """
+    tags = ['call:values', 'func:regex_match']
+    template = {
+        '$': 'call',
+        'name': 'regex_match',
+        'values': [{'$': 'this'}, r'(\w+)@(\w+)'],
+    }
+    data = 'user@host'
+    result = ['user', 'host']
+
+
+class RegexMatchNone(base.TableDataBaseCase):
+    """
+    Returns `null` from `regex_match` when the pattern does not match.
+    """
+    tags = ['call:values', 'func:regex_match']
+    template = {
+        '$': 'call',
+        'name': 'regex_match',
+        'values': [{'$': 'this'}, r'^\d+$'],
+    }
+    data = 'abc'
+    result = None
+
+
+class RegexReplace(base.TableDataBaseCase):
+    """
+    Replaces regex matches with `regex_replace`.
+    """
+    tags = ['call:values', 'func:regex_replace']
+    template = {
+        '$': 'call',
+        'name': 'regex_replace',
+        'values': [{'$': 'this'}, r'\d+', '#'],
+    }
+    data = 'a1b22c'
+    result = 'a#b#c'

--- a/transon/tests/test_functions_string.py
+++ b/transon/tests/test_functions_string.py
@@ -1,0 +1,159 @@
+from . import base
+
+
+class UpperString(base.TableDataBaseCase):
+    """
+    Uppercases a string with the `upper` function.
+    """
+    tags = ['call', 'func:upper']
+    template = {'$': 'call', 'name': 'upper'}
+    data = 'usd'
+    result = 'USD'
+
+
+class LowerString(base.TableDataBaseCase):
+    """
+    Lowercases a string with the `lower` function.
+    """
+    tags = ['call', 'func:lower']
+    template = {'$': 'call', 'name': 'lower'}
+    data = 'USD'
+    result = 'usd'
+
+
+class CapitalizeString(base.TableDataBaseCase):
+    """
+    Capitalizes a string with the `capitalize` function.
+    """
+    tags = ['call', 'func:capitalize']
+    template = {'$': 'call', 'name': 'capitalize'}
+    data = 'hello world'
+    result = 'Hello world'
+
+
+class ReplaceSubstring(base.TableDataBaseCase):
+    """
+    Replaces all occurrences of a substring with `replace`.
+    """
+    tags = ['call:values', 'func:replace']
+    template = {
+        '$': 'call',
+        'name': 'replace',
+        'values': [{'$': 'this'}, 'foo', 'bar'],
+    }
+    data = 'foo-foo'
+    result = 'bar-bar'
+
+
+class RemovePrefix(base.TableDataBaseCase):
+    """
+    Removes an exact prefix with `removeprefix` (unlike character-set `lstrip`).
+    """
+    tags = ['call:values', 'func:removeprefix']
+    template = {
+        '$': 'call',
+        'name': 'removeprefix',
+        'values': [{'$': 'this'}, 'refs/heads/'],
+    }
+    data = 'refs/heads/main'
+    result = 'main'
+
+
+class RemoveSuffix(base.TableDataBaseCase):
+    """
+    Removes an exact suffix with `removesuffix`.
+    """
+    tags = ['call:values', 'func:removesuffix']
+    template = {
+        '$': 'call',
+        'name': 'removesuffix',
+        'values': [{'$': 'this'}, '.git'],
+    }
+    data = 'repo.git'
+    result = 'repo'
+
+
+class StripWhitespace(base.TableDataBaseCase):
+    """
+    Strips leading and trailing whitespace with `strip`.
+    """
+    tags = ['call', 'func:strip']
+    template = {'$': 'call', 'name': 'strip'}
+    data = '  hello  '
+    result = 'hello'
+
+
+class LstripChars(base.TableDataBaseCase):
+    """
+    Strips a leading character set with `lstrip`.
+    """
+    tags = ['call:values', 'func:lstrip']
+    template = {
+        '$': 'call',
+        'name': 'lstrip',
+        'values': [{'$': 'this'}, '0'],
+    }
+    data = '00123'
+    result = '123'
+
+
+class RstripChars(base.TableDataBaseCase):
+    """
+    Strips a trailing character set with `rstrip`.
+    """
+    tags = ['call:values', 'func:rstrip']
+    template = {
+        '$': 'call',
+        'name': 'rstrip',
+        'values': [{'$': 'this'}, '0'],
+    }
+    data = '12300'
+    result = '123'
+
+
+class SliceString(base.TableDataBaseCase):
+    """
+    Slices a string with `slice` using start and stop indices.
+    """
+    tags = ['call:values', 'func:slice']
+    template = {
+        '$': 'call',
+        'name': 'slice',
+        'values': [{'$': 'this'}, 1, 4],
+    }
+    data = 'abcdef'
+    result = 'bcd'
+
+
+class SliceArray(base.TableDataBaseCase):
+    """
+    Slices an array with `slice` from a start index to the end.
+    """
+    tags = ['call:values', 'func:slice']
+    template = {
+        '$': 'call',
+        'name': 'slice',
+        'values': [{'$': 'this'}, 1],
+    }
+    data = [10, 20, 30, 40]
+    result = [20, 30, 40]
+
+
+class ReversedString(base.TableDataBaseCase):
+    """
+    Reverses a string with `reversed`.
+    """
+    tags = ['call', 'func:reversed']
+    template = {'$': 'call', 'name': 'reversed'}
+    data = 'abc'
+    result = 'cba'
+
+
+class ReversedArray(base.TableDataBaseCase):
+    """
+    Reverses an array with `reversed`.
+    """
+    tags = ['call', 'func:reversed']
+    template = {'$': 'call', 'name': 'reversed'}
+    data = [1, 2, 3]
+    result = [3, 2, 1]

--- a/transon/tests/test_operators.py
+++ b/transon/tests/test_operators.py
@@ -173,3 +173,17 @@ class OperatorInObjectKey(base.TableDataBaseCase):
     }
     data = 'name'
     result = True
+
+
+class OperatorInString(base.TableDataBaseCase):
+    """
+    `in` returns `true` when the left operand is a substring of a string.
+    """
+    tags = ['op:in', 'expr:value']
+    template = {
+        '$': 'expr',
+        'op': 'in',
+        'value': 'transon',
+    }
+    data = 'son'
+    result = True

--- a/transon/tests/test_operators.py
+++ b/transon/tests/test_operators.py
@@ -144,3 +144,32 @@ class OperatorModulo(base.TableDataBaseCase):
     }
     data = 9
     result = 1
+
+
+class OperatorInArray(base.TableDataBaseCase):
+    """
+    `in` returns `true` when the left operand is an element of an array.
+    Total — never raises.
+    """
+    tags = ['op:in', 'expr:value']
+    template = {
+        '$': 'expr',
+        'op': 'in',
+        'value': ['a', 'b', 'c'],
+    }
+    data = 'b'
+    result = True
+
+
+class OperatorInObjectKey(base.TableDataBaseCase):
+    """
+    `in` returns `true` when the left operand is a key of an object.
+    """
+    tags = ['op:in', 'expr:value']
+    template = {
+        '$': 'expr',
+        'op': 'in',
+        'value': {'name': 'Ada', 'role': 'engineer'},
+    }
+    data = 'name'
+    result = True

--- a/transon/tests/test_split.py
+++ b/transon/tests/test_split.py
@@ -1,0 +1,31 @@
+from . import base
+
+
+class SplitString(base.TableDataBaseCase):
+    """
+    Splits a string on a separator into a list of strings — the inverse of `join`.
+    """
+    tags = ['split', 'split:sep']
+    template = {'$': 'split', 'sep': '/'}
+    data = 'refs/heads/main'
+    result = ['refs', 'heads', 'main']
+
+
+class SplitArrayOnElement(base.TableDataBaseCase):
+    """
+    Splits an array into sub-arrays on elements equal to `sep`.
+    """
+    tags = ['split', 'split:sep']
+    template = {'$': 'split', 'sep': 0}
+    data = [1, 0, 2, 0, 3]
+    result = [[1], [2], [3]]
+
+
+class SplitArrayOnSubsequence(base.TableDataBaseCase):
+    """
+    Splits an array on each contiguous occurrence of an array `sep` (subsequence).
+    """
+    tags = ['split', 'split:sep']
+    template = {'$': 'split', 'sep': [0, 0]}
+    data = [1, 0, 0, 2, 0, 0, 3]
+    result = [[1], [2], [3]]

--- a/uv.lock
+++ b/uv.lock
@@ -455,7 +455,7 @@ wheels = [
 
 [[package]]
 name = "transon"
-version = "0.1.6"
+version = "0.1.7"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- Add 30 new `call` functions (string/case, slice, epoch dates, collections/numerics, bool, base64, uuid5, regex), a `split` rule (strings + arrays, `NO_CONTENT` passthrough), and a total binary `in` membership operator — all additive, with failures raised as `TransformationError`.
- Spec, corpus examples, error-path tests, and ROADMAP R-33 marked done under `[Unreleased]`; no version bump (0.2.0 held with RFC 0008 language-reference export).
- Closes the measured authoring capability gaps (uppercase, prefix strip, epoch→ISO) and collapses common reduce idioms (`length`/`flatten`/`sum`).

## Test plan
- [x] `uv run pytest .` (378 passed; `functions.py` 100% coverage)
- [x] `uv run python -m transon.docs` — no TBD
- [x] `python scripts/check_roadmap.py` — consistent
- [ ] CI green on this PR
- [ ] Spot-check metadata: `get_editor_metadata()` lists new functions/`in`/`split` with example refs


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the built-in function library with new string, numeric, collection, date/epoch, encoding (Base64), UUIDv5, and regex utilities.
  * Added the `split` transformation rule for strings and arrays, including `NO_CONTENT` passthrough behavior.
  * Added a total `in` membership operator for arrays, strings, and object keys that never errors.

* **Documentation**
  * Updated the specification, roadmap, and release notes to reflect the new rule/operator/function set and contracts.

* **Tests**
  * Added comprehensive documentation and edge-case coverage for the new functions, `split`, and `in`, including error-path validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->